### PR TITLE
include svgs in dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="BSD 3-Clause",
     download_url="https://github.com/hanjinliu/tabulous",
     packages=find_packages(exclude=["docs", "examples", "rst", "tests", "tests.*"]),
-    package_data={"tabulous": ["**/*.pyi", "*.pyi"]},
+    package_data={"tabulous": ["**/*.pyi", "*.pyi", "**/*.svg"]},
     install_requires=[
         "magicgui>=0.5.1",
         "qtpy>=1.10.0",


### PR DESCRIPTION
Hey @hanjinliu, this package looks very exciting!

I just tried to run the demo and got: 

```python
File ~/mambaforge/envs/all/lib/python3.10/site-packages/tabulous/_qt/_svg.py:57, in QColoredSVGIcon.fromfile(cls, path, color)
     55 @classmethod
     56 def fromfile(cls: type[QColoredSVGIcon], path: str | Path, color="#000000"):
---> 57     with open(path, "r") as f:
     58         xml = f.read()
     59     return cls(xml, color=color)

FileNotFoundError: [Errno 2] No such file or directory: '/Users/talley/mambaforge/envs/all/lib/python3.10/site-packages/tabulous/_qt/_icons/open_table.svg'
```

looks like the svgs didn't make it into the distribution, this should fix it