### PR TITLE
add column dtype to spreadsheet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "qtpy>=1.10.0",
         "pandas>=1.0.0",
         "collections-undo>=0.0.6",
+        "appdirs>=1.4.4",
         "qtconsole",
     ],
     extras_require={"all": ["seaborn>=0.11", "matplotlib>=3.1", "pyqt5>=5.12.3"]},

--- a/tabulous/_qt/_action_registry.py
+++ b/tabulous/_qt/_action_registry.py
@@ -46,6 +46,9 @@ class QActionRegistry(QtCore.QObject, Generic[_T]):
 
         return wrapper
 
+    def addSeparator(self):
+        return self._qt_context_menu.addSeparator()
+
     def execContextMenu(self, index: _T) -> None:
         """Execute the context menu at the given index."""
         return self._qt_context_menu.execAtIndex(QtGui.QCursor().pos(), index)

--- a/tabulous/_qt/_table/_base/_colormap.py
+++ b/tabulous/_qt/_table/_base/_colormap.py
@@ -48,7 +48,9 @@ def exec_colormap_dialog(ds: pd.Series, parent=None) -> Callable | None:
             )
 
     else:
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"Dtype {dtype!r} not supported. Please set colormap programmatically."
+        )
 
     return None
 

--- a/tabulous/_qt/_table/_base/_item_model.py
+++ b/tabulous/_qt/_table/_base/_item_model.py
@@ -111,7 +111,7 @@ class AbstractDataFrameModel(QtCore.QAbstractTableModel):
                 except Exception as e:
                     # since this method is called many times, errorous function should be
                     # deleted from the mapper.
-                    self._background_colormap.pop(c)
+                    self._background_colormap.pop(colname)
                     raise e
                 return QtGui.QColor(*rgba)
         return QtCore.QVariant()
@@ -136,9 +136,7 @@ class AbstractDataFrameModel(QtCore.QAbstractTableModel):
                 return None
             elif role == Qt.ItemDataRole.ToolTipRole:
                 if section < self.df.columns.size:
-                    name = self.df.columns[section]
-                    dtype = self.df.dtypes.values[section]
-                    return f"{name} (dtype: {dtype})"
+                    return self._column_tooltip(section)
                 return None
 
         if orientation == Qt.Orientation.Vertical:
@@ -146,6 +144,11 @@ class AbstractDataFrameModel(QtCore.QAbstractTableModel):
                 if section < self.df.index.size:
                     return str(self.df.index[section])
                 return None
+
+    def _column_tooltip(self, section: int):
+        name = self.df.columns[section]
+        dtype = self.df.dtypes.values[section]
+        return f"{name} (dtype: {dtype})"
 
     def setData(self, index: QtCore.QModelIndex, value, role) -> bool:
         if not index.isValid():

--- a/tabulous/_qt/_table/_base/_table_base.py
+++ b/tabulous/_qt/_table/_base/_table_base.py
@@ -115,10 +115,11 @@ class QBaseTable(QtW.QSplitter, QActionRegistry[Tuple[int, int]]):
     def _install_actions(self):
         hheader = self._qtable_view.horizontalHeader()
         hheader.registerAction("Set forground colormap")(self._set_forground_colormap)
-        hheader.registerAction("Set background colormap")(self._set_background_colormap)
         hheader.registerAction("Reset forground colormap")(
             self._reset_forground_colormap
         )
+        self.addSeparator()
+        hheader.registerAction("Set background colormap")(self._set_background_colormap)
         hheader.registerAction("Reset background colormap")(
             self._reset_background_colormap
         )

--- a/tabulous/_qt/_table/_dtype.py
+++ b/tabulous/_qt/_table/_dtype.py
@@ -145,6 +145,10 @@ class DTypeMap(MutableMapping[_K, _V]):
         self._datetime_dict: dict[Hashable, _DTypeLike] = {}
         self._timedelta_dict: dict[Hashable, _DTypeLike] = {}
 
+    def __repr__(self) -> str:
+        clsname = type(self).__name__
+        return f"{clsname}{dict(**self)!r}"
+
     def __getitem__(self, key: _K) -> _V:
         out = self._dict.get(key, None)
         if out is None:

--- a/tabulous/_qt/_table/_dtype.py
+++ b/tabulous/_qt/_table/_dtype.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+from typing import Any, Callable
+import pandas as pd
+
+_NAN_STRINGS = frozenset({"", "nan", "na", "n/a", "<na>", "NaN", "NA", "N/A", "<NA>"})
+
+
+def _bool_converter(val: Any):
+    if isinstance(val, str):
+        if val in ("True", "1", "true"):
+            return True
+        elif val in ("False", "0", "false"):
+            return False
+        else:
+            raise ValueError(f"Cannot convert {val} to bool.")
+    else:
+        return bool(val)
+
+
+def _float_or_nan(x: Any):
+    if x in _NAN_STRINGS:
+        return float("nan")
+    return float(x)
+
+
+def _complex_or_nan(x: Any):
+    if x in _NAN_STRINGS:
+        return float("nan")
+    return complex(x)
+
+
+_DTYPE_CONVERTER = {
+    "i": int,
+    "f": _float_or_nan,
+    "u": int,
+    "b": _bool_converter,
+    "U": str,
+    "O": lambda e: e,
+    "c": _complex_or_nan,
+    "M": pd.to_datetime,
+    "m": pd.to_timedelta,
+}
+
+
+def convert_value(kind: str, value: Any) -> Any:
+    """Convert value according to the dtype kind."""
+    return _DTYPE_CONVERTER[kind](value)
+
+
+def get_converter(kind: str) -> Callable[[Any], Any]:
+    return _DTYPE_CONVERTER[kind]

--- a/tabulous/_qt/_table/_dtype.py
+++ b/tabulous/_qt/_table/_dtype.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Any, Callable
 import pandas as pd
+from qtpy import QtWidgets as QtW
+from qtpy.QtCore import Qt
 
 _NAN_STRINGS = frozenset({"", "nan", "na", "n/a", "<na>", "NaN", "NA", "N/A", "<NA>"})
 
@@ -49,3 +51,68 @@ def convert_value(kind: str, value: Any) -> Any:
 
 def get_converter(kind: str) -> Callable[[Any], Any]:
     return _DTYPE_CONVERTER[kind]
+
+
+class QDtypeWidget(QtW.QTreeWidget):
+    _DTYPES = [
+        "unset",
+        "int",
+        "uint",
+        "float",
+        "complex",
+        "bool",
+        "time",
+        "others",
+    ]
+
+    _SUB_DTYPES = {
+        "int": ["int8", "int16", "int32", "int64"],
+        "uint": ["uint8", "uint16", "uint32", "uint64"],
+        "float": ["float16", "float32", "float64"],
+        "complex": ["complex64", "complex128"],
+        "time": ["datetime64", "timedelta64"],
+        "others": [
+            "category",
+            "string",
+            "object",
+        ],
+    }
+
+    def __init__(self, parent: QtW.QWidget | None = None):
+        super().__init__(parent)
+        self.setHeaderHidden(True)
+
+        for dtype in self._DTYPES:
+            item = QtW.QTreeWidgetItem([dtype])
+            self.addTopLevelItem(item)
+            if sub := self._SUB_DTYPES.get(dtype, None):
+                item.addChildren(QtW.QTreeWidgetItem([s]) for s in sub)
+
+        self.setSelectionMode(QtW.QTreeWidget.SelectionMode.SingleSelection)
+
+    def dtypeText(self) -> str:
+        """Get the selected dtype as a text."""
+        return self.currentItem().text(0)
+
+    @classmethod
+    def requestValue(cls, parent=None) -> str | None:
+        self = cls()
+        dlg = QtW.QDialog(parent)
+        dlg.setLayout(QtW.QVBoxLayout())
+        dlg.layout().addWidget(QtW.QLabel("dtype"))
+        dlg.layout().addWidget(self)
+
+        _Btn = QtW.QDialogButtonBox.StandardButton
+        _btn_box = QtW.QDialogButtonBox(
+            _Btn.Ok | _Btn.Cancel,
+            Qt.Orientation.Horizontal,
+        )
+        _btn_box.accepted.connect(dlg.accept)
+        _btn_box.rejected.connect(dlg.reject)
+        dlg.layout().addWidget(_btn_box)
+        dlg.setWindowTitle("Select a dtype")
+        if dlg.exec():
+            out = self.dtypeText()
+        else:
+            out = None
+        return out

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -387,7 +387,7 @@ class QSpreadSheet(QMutableSimpleTable):
             self._columns_dtype.pop(label, None)
             return None
         if label not in self._data_raw.columns:
-            raise KeyError(f"Column {label} not found.")
+            raise ValueError(f"Column {label!r} not found.")
         from pandas.core.dtypes.common import pandas_dtype
 
         dtype = pandas_dtype(dtype)

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -375,7 +375,7 @@ class QSpreadSheet(QMutableSimpleTable):
         return None
 
     @QMutableSimpleTable._mgr.interface
-    def setColumnDtype(self, label: Hashable, dtype: Any) -> None:
+    def setColumnDtype(self, label: Hashable, dtype: Any | None) -> None:
         """Set the dtype of the column with the given label."""
         if dtype is None:
             self._columns_dtype.pop(label, None)

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -311,6 +311,12 @@ class QSpreadSheet(QMutableSimpleTable):
 
     @QMutableSimpleTable._mgr.undoable
     def _remove_columns(self, column: int, count: int, old_values: pd.DataFrame):
+        model = self.model()
+        for index in range(column, column + count):
+            colname = model.df.columns[index]
+            model._background_colormap.pop(colname, None)
+            model._foreground_colormap.pop(colname, None)
+
         self._data_raw = pd.concat(
             [self._data_raw.iloc[:, :column], self._data_raw.iloc[:, column + count :]],
             axis=1,
@@ -412,6 +418,11 @@ class QSpreadSheet(QMutableSimpleTable):
     def _remove_this_column(self, col: int):
         return self.removeColumns(col, 1)
 
+    def _set_column_dtype(self, col: int):
+        from magicgui.widgets import Dialog
+
+        # TODO: use a dialog to set the dtype
+
     def _install_actions(self):
         # fmt: off
         vheader = self._qtable_view.verticalHeader()
@@ -423,6 +434,7 @@ class QSpreadSheet(QMutableSimpleTable):
         hheader.registerAction("Insert column left")(self._insert_column_left)
         hheader.registerAction("Insert column right")(self._insert_column_right)
         hheader.registerAction("Remove this column")(self._remove_this_column)
+        hheader.registerAction("Set column dtype")(self._set_column_dtype)
 
         self.registerAction("Insert a row above")(lambda idx: self._insert_row_above(idx[0]))
         self.registerAction("Insert a row below")(lambda idx: self._insert_row_below(idx[0]))

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -419,9 +419,13 @@ class QSpreadSheet(QMutableSimpleTable):
         return self.removeColumns(col, 1)
 
     def _set_column_dtype(self, col: int):
-        from magicgui.widgets import Dialog
+        from ._dtype import QDtypeWidget
 
-        # TODO: use a dialog to set the dtype
+        if val := QDtypeWidget.requestValue(self):
+            if val == "unset":
+                val = None
+            self.setColumnDtype(self._filtered_columns[col], val)
+        return None
 
     def _install_actions(self):
         # fmt: off
@@ -429,19 +433,24 @@ class QSpreadSheet(QMutableSimpleTable):
         vheader.registerAction("Insert row above")(self._insert_row_above)
         vheader.registerAction("Insert row below")(self._insert_row_below)
         vheader.registerAction("Remove this row")(self._remove_this_row)
+        vheader.addSeparator()
 
         hheader = self._qtable_view.horizontalHeader()
         hheader.registerAction("Insert column left")(self._insert_column_left)
         hheader.registerAction("Insert column right")(self._insert_column_right)
         hheader.registerAction("Remove this column")(self._remove_this_column)
+        hheader.addSeparator()
         hheader.registerAction("Set column dtype")(self._set_column_dtype)
+        hheader.addSeparator()
 
         self.registerAction("Insert a row above")(lambda idx: self._insert_row_above(idx[0]))
         self.registerAction("Insert a row below")(lambda idx: self._insert_row_below(idx[0]))
+        self.registerAction("Remove this row")(lambda idx: self._remove_this_row(idx[0]))
+        self.addSeparator()
         self.registerAction("Insert a column on the left")(lambda idx: self.insertColumns(idx[1]))
         self.registerAction("Insert a column on the right")(lambda idx: self.insertColumns(idx[1]))
-        self.registerAction("Remove this row")(lambda idx: self._remove_this_row(idx[0]))
         self.registerAction("Remove this column")(lambda idx: self._remove_this_column(idx[1]))
+        self.addSeparator()
         # fmt: on
 
         super()._install_actions()

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -312,6 +312,7 @@ class QSpreadSheet(QMutableSimpleTable):
             colname = model.df.columns[index]
             model._background_colormap.pop(colname, None)
             model._foreground_colormap.pop(colname, None)
+            self._columns_dtype.pop(colname, None)
 
         self._data_raw = pd.concat(
             [self._data_raw.iloc[:, :column], self._data_raw.iloc[:, column + count :]],
@@ -367,11 +368,11 @@ class QSpreadSheet(QMutableSimpleTable):
         with self._mgr.merging(formatter=lambda cmds: cmds[-1].format()):
             if index >= ncols:
                 self.expandDataFrame(0, index - ncols + 1)
-            colname = self._data_raw.columns[index]
+            old_name = self._data_raw.columns[index]
             self.setFilter(self._filter_slice)
             super().setHorizontalHeaderValue(index, value)
-            if colname in self._columns_dtype.keys():
-                self.setColumnDtype(colname, self._columns_dtype[colname])
+            if old_name in self._columns_dtype.keys():
+                self.setColumnDtype(value, self._columns_dtype.pop(old_name))
             self._data_cache = None
 
         return None

--- a/tabulous/_qt/_table/_table.py
+++ b/tabulous/_qt/_table/_table.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 from typing import Any
 import pandas as pd
+
 from ._base import QMutableSimpleTable, DataFrameModel
+from ._dtype import convert_value
 
 
 class QTableLayer(QMutableSimpleTable):
@@ -35,44 +37,4 @@ class QTableLayer(QMutableSimpleTable):
     def convertValue(self, r: int, c: int, value: Any) -> Any:
         """Convert value to the type of the table."""
         kind = self._data_raw.dtypes[c].kind
-        return _DTYPE_CONVERTER[kind](value)
-
-
-def _bool_converter(val: Any):
-    if isinstance(val, str):
-        if val in ("True", "1", "true"):
-            return True
-        elif val in ("False", "0", "false"):
-            return False
-        else:
-            raise ValueError(f"Cannot convert {val} to bool.")
-    else:
-        return bool(val)
-
-
-_NAN_STRINGS = frozenset({"", "nan", "na", "n/a", "<na>", "NaN", "NA", "N/A", "<NA>"})
-
-
-def _float_or_nan(x: Any):
-    if x in _NAN_STRINGS:
-        return float("nan")
-    return float(x)
-
-
-def _complex_or_nan(x: Any):
-    if x in _NAN_STRINGS:
-        return float("nan")
-    return complex(x)
-
-
-_DTYPE_CONVERTER = {
-    "i": int,
-    "f": _float_or_nan,
-    "u": int,
-    "b": _bool_converter,
-    "U": str,
-    "O": lambda e: e,
-    "c": _complex_or_nan,
-    "M": pd.to_datetime,
-    "m": pd.to_timedelta,
-}
+        return convert_value(kind, value)

--- a/tabulous/_qt/_table_stack/_start.py
+++ b/tabulous/_qt/_table_stack/_start.py
@@ -14,6 +14,8 @@ _HEIGHT = 24
 
 
 class QStartupWidget(QtW.QWidget):
+    """The startup widget which is shown when no table exists."""
+
     def __init__(self, parent=None):
         super().__init__(parent)
         _layout = QtW.QVBoxLayout()
@@ -21,19 +23,17 @@ class QStartupWidget(QtW.QWidget):
         _layout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.setLayout(_layout)
 
+        # fmt: off
         self._open_table_btn = QClickableLabel("Open File as Table (Ctrl+O)")
-        self._open_spreadsheet_btn = QClickableLabel(
-            "Open File as Spreadsheet (Ctrl+K, Ctrl+O)"
-        )
+        self._open_spreadsheet_btn = QClickableLabel("Open File as Spreadsheet (Ctrl+K, Ctrl+O)")
         self._open_new_btn = QClickableLabel("New Spreadsheet (Ctrl+N)")
         self._path_list = QPathList()
 
-        self._open_table_btn.clicked.connect(lambda: self.mainWidget().openFromDialog())
+        self._open_table_btn.clicked.connect(lambda: self.mainWidget().openFromDialog(type="table"))
+        self._open_spreadsheet_btn.clicked.connect(lambda: self.mainWidget().openFromDialog(type="spreadsheet"))
         self._open_new_btn.clicked.connect(lambda: self.mainWidget().newSpreadSheet())
-        self._path_list.pathClicked.connect(
-            lambda path: self.mainWidget()._table_viewer.open(path)
-        )
-
+        self._path_list.pathClicked.connect(lambda path: self.mainWidget()._table_viewer.open(path))
+        # fmt: on
         _layout.addWidget(self._open_table_btn)
         _layout.addWidget(self._open_spreadsheet_btn)
         _layout.addWidget(self._open_new_btn)

--- a/tabulous/_utils.py
+++ b/tabulous/_utils.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 from pathlib import Path
+from appdirs import user_state_dir
 
-TXT_PATH = Path(__file__).parent / "_tabulous_history.txt"
+TXT_PATH = Path(user_state_dir("tabulous", "tabulous", "history.txt"))
 
 
 def dump_file_open_path(path: str):
     path = str(path)
     try:
         if not TXT_PATH.exists():
+            TXT_PATH.parent.mkdir(parents=True, exist_ok=True)
             TXT_PATH.write_text("")
         with open(TXT_PATH, "r+") as f:
             lines = [s.strip() for s in f.readlines()]

--- a/tabulous/widgets/_component.py
+++ b/tabulous/widgets/_component.py
@@ -10,6 +10,8 @@ from typing import (
     Any,
     Callable,
     Union,
+    MutableMapping,
+    Iterator,
 )
 
 import numpy as np
@@ -318,7 +320,9 @@ class PlotInterface(Component["TableBase"]):
         return self._current_widget.draw()
 
 
-class ColumnDtypeInterface(Component["SpreadSheet"]):
+class ColumnDtypeInterface(
+    Component["SpreadSheet"], MutableMapping[Hashable, "_DtypeLike"]
+):
     """Interface to the column dtype of spreadsheet."""
 
     def __getitem__(self, key: Hashable) -> _DtypeLike | None:
@@ -334,3 +338,9 @@ class ColumnDtypeInterface(Component["SpreadSheet"]):
         clsname = type(self).__name__
         dict = self.parent._qwidget._columns_dtype
         return f"{clsname}({dict!r})"
+
+    def __len__(self) -> str:
+        return len(self.parent._qwidget._columns_dtype)
+
+    def __iter__(self) -> Iterator[Hashable]:
+        return iter(self.parent._qwidget._columns_dtype)

--- a/tabulous/widgets/_component.py
+++ b/tabulous/widgets/_component.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 import weakref
-from typing import Generic, Literal, TYPE_CHECKING, TypeVar, overload, Any, Callable
+from typing import (
+    Generic,
+    Hashable,
+    Literal,
+    TYPE_CHECKING,
+    TypeVar,
+    overload,
+    Any,
+    Callable,
+    Union,
+)
+
+import numpy as np
 from ..exceptions import TableImmutableError
 
 if TYPE_CHECKING:
     from typing_extensions import Self
-    from ._table import TableBase
+    from pandas.core.dtypes.dtypes import ExtensionDtype
+    from ._table import TableBase, SpreadSheet
     from .._qt._table._base._header_view import QDataFrameHeaderView
+
+    _DtypeLike = Union[np.dtype, ExtensionDtype]
 
 T = TypeVar("T")
 _F = TypeVar("_F", bound=Callable)
@@ -301,3 +316,21 @@ class PlotInterface(Component["TableBase"]):
     def draw(self):
         """Update the current side figure."""
         return self._current_widget.draw()
+
+
+class ColumnDtypeInterface(Component["SpreadSheet"]):
+    """Interface to the column dtype of spreadsheet."""
+
+    def __getitem__(self, key: Hashable) -> _DtypeLike | None:
+        return self.parent._qwidget._columns_dtype.get(key, None)
+
+    def __setitem__(self, key: Hashable, dtype: Any) -> None:
+        return self.parent._qwidget.setColumnDtype(key, dtype)
+
+    def __delitem__(self, key: Hashable) -> None:
+        return self.parent._qwidget.setColumnDtype(None)
+
+    def __repr__(self) -> str:
+        clsname = type(self).__name__
+        dict = self.parent._qwidget._columns_dtype
+        return f"{clsname}({dict!r})"

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -265,9 +265,7 @@ class TableBase(ABC):
         """
 
         def _wrapper(f: ColorMapping) -> ColorMapping:
-            model = self._qwidget.model()
-            model._foreground_colormap[column_name] = f
-            self.refresh()
+            self._qwidget.setForegroundColormap(column_name, f)
             return f
 
         return _wrapper(colormap) if colormap is not None else _wrapper
@@ -290,9 +288,7 @@ class TableBase(ABC):
         """
 
         def _wrapper(f: ColorMapping) -> ColorMapping:
-            model = self._qwidget.model()
-            model._background_colormap[column_name] = f
-            self.refresh()
+            self._qwidget.setBackgroundColormap(column_name, f)
             return f
 
         return _wrapper(colormap) if colormap is not None else _wrapper

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -397,6 +397,10 @@ class SpreadSheet(_DataFrameTableLayer):
 
         return QSpreadSheet(data=data)
 
+    def set_dtype(self, name, dtype):
+        self._qwidget.setColumnDtype(name, dtype)
+        return None
+
 
 class GroupBy(TableBase):
     """

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -10,6 +10,7 @@ from ._component import (
     HorizontalHeaderInterface,
     VerticalHeaderInterface,
     PlotInterface,
+    ColumnDtypeInterface,
 )
 from . import _doc
 
@@ -389,17 +390,14 @@ class SpreadSheet(_DataFrameTableLayer):
     {name}{editable}{metadata}
     """
 
-    _Default_Name = "sheet"
     _qwidget: QSpreadSheet
+    _Default_Name = "sheet"
+    dtypes = ColumnDtypeInterface()
 
     def _create_backend(self, data: pd.DataFrame) -> QSpreadSheet:
         from .._qt import QSpreadSheet
 
         return QSpreadSheet(data=data)
-
-    def set_dtype(self, name, dtype):
-        self._qwidget.setColumnDtype(name, dtype)
-        return None
 
 
 class GroupBy(TableBase):

--- a/tabulous/widgets/mainwindow.py
+++ b/tabulous/widgets/mainwindow.py
@@ -204,6 +204,7 @@ class TableViewerBase:
         copy: bool = True,
         metadata: dict[str, Any] | None = None,
         update: bool = False,
+        dtyped: bool = False,
     ) -> SpreadSheet:
         """
         Add data as a spreadsheet.
@@ -213,6 +214,9 @@ class TableViewerBase:
         data : DataFrame like, optional
             Table data to add.
         {name}{editable}{copy}{metadata}{update}
+        dtyped : bool, default is False
+            If True, dtypes of the dataframe columns will be saved in the spreadsheet.
+            Typed spreadsheet is safer for data recovery but less flexible for editing.
 
         Returns
         -------
@@ -222,6 +226,8 @@ class TableViewerBase:
         if copy:
             data = _copy_dataframe(data)
         table = SpreadSheet(data, name=name, editable=editable, metadata=metadata)
+        if dtyped:
+            table.dtypes.update(data.dtypes)
         return self.add_layer(table, update=update)
 
     def add_groupby(

--- a/tabulous/widgets/mainwindow.py
+++ b/tabulous/widgets/mainwindow.py
@@ -139,11 +139,6 @@ class TableViewerBase:
         """Return the index of currently visible table."""
         return self._qwidget._tablestack.currentIndex()
 
-    @property
-    def native(self) -> _QtMainWidgetBase:
-        """Return the native widget."""
-        return self._qwidget
-
     @current_index.setter
     def current_index(self, index: int | str):
         if isinstance(index, str):
@@ -151,6 +146,11 @@ class TableViewerBase:
         elif index < 0:
             index += len(self.tables)
         return self._qwidget._tablestack.setCurrentIndex(index)
+
+    @property
+    def native(self) -> _QtMainWidgetBase:
+        """Return the native widget."""
+        return self._qwidget
 
     def show(self, *, run: bool = True) -> None:
         """Show the widget."""

--- a/tabulous/widgets/mainwindow.py
+++ b/tabulous/widgets/mainwindow.py
@@ -363,6 +363,10 @@ class TableViewerBase:
             self.current_table.selections = selections
         return self.current_table._qwidget.pasteFromClipBoard()
 
+    def close(self):
+        """Close the viewer."""
+        return self._qwidget.close()
+
     def _link_events(self):
         _tablist = self._tablist
         _qtablist = self._qwidget._tablestack

--- a/tests/test_column_dtype.py
+++ b/tests/test_column_dtype.py
@@ -34,3 +34,29 @@ def test_timedelta():
 
     sheet.dtypes["timedelta"] = "timedelta64[ns]"
     assert sheet.data.dtypes[0] == "timedelta64[ns]"
+
+def test_updating_column_name():
+    viewer = TableViewer(show=False)
+    sheet = viewer.add_spreadsheet({"number": [1, 2, 3], "char": ["a", "b", "a"]})
+
+    sheet.dtypes["number"] = "float32"
+    sheet.dtypes["char"] = "category"
+
+    assert sheet.dtypes == {"number": "float32", "char": "category"}
+
+    sheet.columns[0] = "new_name"
+
+    assert sheet.dtypes == {"new_name": "float32", "char": "category"}
+
+def test_deleting_column_name():
+    viewer = TableViewer(show=False)
+    sheet = viewer.add_spreadsheet({"number": [1, 2, 3], "char": ["a", "b", "a"]})
+
+    sheet.dtypes["number"] = "float32"
+    sheet.dtypes["char"] = "category"
+
+    assert sheet.dtypes == {"number": "float32", "char": "category"}
+
+    sheet.native.removeColumns(0, 1)
+
+    assert sheet.dtypes == {"char": "category"}

--- a/tests/test_column_dtype.py
+++ b/tests/test_column_dtype.py
@@ -1,0 +1,36 @@
+from tabulous import TableViewer
+
+def test_setting_column_dtype():
+    viewer = TableViewer(show=False)
+    sheet = viewer.add_spreadsheet({"number": [1, 2, 3], "char": ["a", "b", "a"]})
+    assert sheet.dtypes == {}
+
+    sheet.dtypes["number"] = "float32"
+    sheet.dtypes["char"] = "category"
+    assert sheet.dtypes == {"number": "float32", "char": "category"}
+
+    df = sheet.data
+    assert df.dtypes[0] == "float32"
+    assert df.dtypes[1] == "category"
+
+    sheet.undo_manager.undo()
+    assert sheet.dtypes == {"number": "float32"}
+
+    sheet.undo_manager.undo()
+    assert sheet.dtypes == {}
+
+def test_datetime():
+    viewer = TableViewer(show=False)
+    sheet = viewer.add_spreadsheet({"datetime": ["2020-01-01", "2020-01-02", "2020-01-03"]})
+    assert sheet.data.dtypes[0] == "object"
+
+    sheet.dtypes["datetime"] = "datetime64[ns]"
+    assert sheet.data.dtypes[0] == "datetime64[ns]"
+
+def test_timedelta():
+    viewer = TableViewer(show=False)
+    sheet = viewer.add_spreadsheet({"timedelta": ["1d", "2d", "3d"]})
+    assert sheet.data.dtypes[0] == "object"
+
+    sheet.dtypes["timedelta"] = "timedelta64[ns]"
+    assert sheet.data.dtypes[0] == "timedelta64[ns]"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,8 +6,8 @@ DATA_PATH = Path(__file__).parent / "data"
 
 def test_view():
     df = pd.read_csv(DATA_PATH / "test.csv")
-    tbl.view_table(df)
-    tbl.view_spreadsheet(df)
+    tbl.view_table(df).close()
+    tbl.view_spreadsheet(df).close()
 
 def test_io():
-    tbl.read_csv(DATA_PATH / "test.csv")
+    tbl.read_csv(DATA_PATH / "test.csv").close()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -83,6 +83,8 @@ def test_components(viewer_cls: type[TableViewerWidget]):
     viewer.toolbar.visible = False
     assert not viewer.toolbar.visible
 
+    viewer.close()
+
 @pytest.mark.parametrize("viewer_cls", [TableViewer, TableViewerWidget])
 def test_bind_keycombo(viewer_cls: type[TableViewerWidget]):
     viewer = viewer_cls()
@@ -97,3 +99,5 @@ def test_bind_keycombo(viewer_cls: type[TableViewerWidget]):
     with pytest.raises(Exception):
         viewer.keymap.bind("T")(mock)
     viewer.keymap.bind("T", overwrite=True)(print)
+
+    viewer.close()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -153,6 +153,7 @@ def test_popup_view():
 
     table.selections = [(slice(1, 2), slice(0, 2))]
     selection_equal(table.selections, [(slice(1, 2), slice(0, 2))])
+    table.view_mode = "normal"
 
 def test_color_mapper():
     viewer = TableViewer(show=False)


### PR DESCRIPTION
Currently it's very hard to specify dtypes such as "category" and "datetime64" in a spreadsheet.
This is also a problem when users try to set colormap to strings because they are always infered to dtype object.

This PR adds `_column_dtype` attribute to `QSpreadSheet` to solve these problems.