### PR TITLE
Text formatter

### DIFF
--- a/examples/02-3_use_validator.py
+++ b/examples/02-3_use_validator.py
@@ -1,0 +1,20 @@
+from tabulous import TableViewer
+
+# You can define validators for each column.
+# A validator is called when a cell is edited, *after* the value is converted
+# to the proper data type.
+
+if __name__ == "__main__":
+    viewer = TableViewer()
+    size = 100
+    table = viewer.add_table(
+        {"name": ["A", "B", "C"], "value": [1, 2, 3]},
+        editable=True,
+    )
+
+    @table.validator("value")
+    def _value_validator(val: int):
+        if val < 0:
+            raise ValueError("Negative values are not allowed")
+
+    viewer.show()

--- a/tabulous/_qt/_style.qss
+++ b/tabulous/_qt/_style.qss
@@ -85,7 +85,7 @@ QTabBar::tab:bottom:selected {
     color: black;
 }
 
-QDtypedLineEdit {
+_QTableLineEdit {
     border: none;
     border-bottom: 2px solid #BADEF4;
 }

--- a/tabulous/_qt/_style.qss
+++ b/tabulous/_qt/_style.qss
@@ -31,7 +31,7 @@ QTableView:focus {
 }
 
 QTableView:item:hover {
-    border: 2px solid #E8E8F6;
+    /* empty style sheet enables paint event on hovering. */
 }
 
 QTableView:item:focus {

--- a/tabulous/_qt/_table/_base/_delegate.py
+++ b/tabulous/_qt/_table/_base/_delegate.py
@@ -21,10 +21,8 @@ class TableItemDelegate(QtW.QStyledItemDelegate):
         self._parent = parent
 
     def replace(self, parent: QtCore.QObject | None = None) -> TableItemDelegate:
+        """Replace with new parent."""
         return TableItemDelegate(parent, self.ndigits)
-
-    def displayText(self, value, locale):
-        return super().displayText(self._format_number(value), locale)
 
     def createEditor(
         self, parent: QtW.QWidget, option, index: QtCore.QModelIndex
@@ -96,32 +94,14 @@ class TableItemDelegate(QtW.QStyledItemDelegate):
         else:
             return super().setModelData(editor, model, index)
 
-    # modified from magicgui
-    def _format_number(self, text: str) -> str:
-        """convert string to int or float if possible"""
-        try:
-            value = int(text)
-        except ValueError:
-            try:
-                value = float(text)
-            except ValueError:
-                return text
-
-        ndigits = self.ndigits
-
-        if isinstance(value, int):
-            if 0.1 <= abs(value) < 10 ** (ndigits + 1) or value == 0:
-                text = str(value)
-            else:
-                text = f"{value:.{ndigits-1}e}"
-
-        elif isinstance(value, float):
-            if 0.1 <= abs(value) < 10 ** (ndigits + 1) or value == 0:
-                text = f"{value:.{ndigits}f}"
-            else:
-                text = f"{value:.{ndigits-1}e}"
-
-        return text
+    def paint(
+        self,
+        painter: QtGui.QPainter,
+        option: QtW.QStyleOptionViewItem,
+        index: QtCore.QModelIndex,
+    ):
+        option.textElideMode = Qt.TextElideMode.ElideNone
+        return super().paint(painter, option, index)
 
     def initStyleOption(
         self, option: QtW.QStyleOptionViewItem, index: QtCore.QModelIndex

--- a/tabulous/_qt/_table/_base/_delegate.py
+++ b/tabulous/_qt/_table/_base/_delegate.py
@@ -10,19 +10,11 @@ if TYPE_CHECKING:
     import numpy as np
     from pandas.core.dtypes.dtypes import CategoricalDtype
     from ._enhanced_table import _QTableViewEnhanced
+    from ._item_model import AbstractDataFrameModel
 
 
 class TableItemDelegate(QtW.QStyledItemDelegate):
     """Displays table widget items with properly formatted numbers."""
-
-    def __init__(self, parent: QtCore.QObject | None = None, ndigits: int = 4) -> None:
-        super().__init__(parent)
-        self.ndigits = ndigits
-        self._parent = parent
-
-    def replace(self, parent: QtCore.QObject | None = None) -> TableItemDelegate:
-        """Replace with new parent."""
-        return TableItemDelegate(parent, self.ndigits)
 
     def createEditor(
         self, parent: QtW.QWidget, option, index: QtCore.QModelIndex
@@ -84,7 +76,7 @@ class TableItemDelegate(QtW.QStyledItemDelegate):
     def setModelData(
         self,
         editor: QtW.QWidget,
-        model: QtCore.QAbstractItemModel,
+        model: AbstractDataFrameModel,
         index: QtCore.QModelIndex,
     ) -> None:
         if isinstance(editor, QtW.QDateTimeEdit):

--- a/tabulous/_qt/_table/_base/_enhanced_table.py
+++ b/tabulous/_qt/_table/_base/_enhanced_table.py
@@ -25,6 +25,7 @@ H_COLOR_B = QtGui.QColor(255, 0, 0, 86)
 S_COLOR_W = Qt.GlobalColor.darkBlue
 S_COLOR_B = Qt.GlobalColor.cyan
 CUR_COLOR = QtGui.QColor(128, 128, 128, 108)
+HOV_COLOR = QtGui.QColor(75, 75, 242, 80)
 
 # fmt: on
 
@@ -435,11 +436,20 @@ class _QTableViewEnhanced(QtW.QTableView):
         # current index
         idx = self._selection_model.current_index
         if idx >= (0, 0):
-            rect_current = self.visualRect(self.model().index(*idx))
-            rect_current.adjust(1, 1, -1, -1)
+            rect_cursor = self.visualRect(self.model().index(*idx))
+            rect_cursor.adjust(1, 1, -1, -1)
             pen = QtGui.QPen(CUR_COLOR, 3)
             painter.setPen(pen)
-            painter.drawRect(rect_current)
+            painter.drawRect(rect_cursor)
+
+        # mouse hover
+        mouse_idx = self.indexAt(self.viewport().mapFromGlobal(QtGui.QCursor.pos()))
+        if mouse_idx.isValid():
+            rect_cursor = self.visualRect(mouse_idx)
+            rect_cursor.adjust(1, 1, -1, -1)
+            pen = QtGui.QPen(HOV_COLOR, 2)
+            painter.setPen(pen)
+            painter.drawRect(rect_cursor)
 
         return None
 

--- a/tabulous/_qt/_table/_base/_enhanced_table.py
+++ b/tabulous/_qt/_table/_base/_enhanced_table.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from ._delegate import TableItemDelegate
     from ..._mainwindow import _QtMainWidgetBase
 
-# fmt: off
 # Flags
 _SCROLL_PER_PIXEL = QtW.QAbstractItemView.ScrollMode.ScrollPerPixel
 
@@ -26,8 +25,6 @@ S_COLOR_W = Qt.GlobalColor.darkBlue
 S_COLOR_B = Qt.GlobalColor.cyan
 CUR_COLOR = QtGui.QColor(128, 128, 128, 108)
 HOV_COLOR = QtGui.QColor(75, 75, 242, 80)
-
-# fmt: on
 
 
 class _QTableViewEnhanced(QtW.QTableView):

--- a/tabulous/_qt/_table/_base/_item_model.py
+++ b/tabulous/_qt/_table/_base/_item_model.py
@@ -26,7 +26,7 @@ class AbstractDataFrameModel(QtCore.QAbstractTableModel):
         self._foreground_colormap: dict[Hashable, Callable[[Any], ColorType]] = {}
         self._background_colormap: dict[Hashable, Callable[[Any], ColorType]] = {}
         self._text_formatter: dict[Hashable, Callable[[Any], str]] = {}
-        self._validator: dict[Hashable, Callable[[Any], bool]] = {}
+        self._validator: dict[Hashable, Callable[[Any], None]] = {}
 
         self._data_role_map = {
             Qt.ItemDataRole.EditRole: self._data_display,
@@ -223,6 +223,8 @@ class AbstractDataFrameModel(QtCore.QAbstractTableModel):
             self.beginRemoveColumns(QtCore.QModelIndex(), c0 + dc, c0 - 1)
             self.removeColumns(c0 + dc, -dc, QtCore.QModelIndex())
             self.endRemoveColumns()
+
+        return None
 
 
 class DataFrameModel(AbstractDataFrameModel):

--- a/tabulous/_qt/_table/_base/_line_edit.py
+++ b/tabulous/_qt/_table/_base/_line_edit.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class _QTableLineEdit(QtW.QLineEdit):
     """LineEdit widget with dtype checker and custom defocusing."""
 
-    _VALID = QtGui.QColor(26, 34, 235, 200)
+    _VALID = QtGui.QColor(186, 222, 244, 200)
     _INVALID = QtGui.QColor(255, 0, 0, 200)
 
     def __init__(
@@ -170,7 +170,7 @@ class _QHeaderLineEdit(_QTableLineEdit):
                 raise err
             return None
 
-        self.setText(str(old_value))
+        self.setText(text)
         self.selectAll()
         self.setFocus()
 

--- a/tabulous/_qt/_table/_base/_table_base.py
+++ b/tabulous/_qt/_table/_base/_table_base.py
@@ -146,6 +146,7 @@ class QBaseTable(QtW.QSplitter, QActionRegistry[Tuple[int, int]]):
         hheader.registerAction("Color>Set background colormap")(self._set_background_colormap_with_dialog)
         hheader.registerAction("Color>Reset background colormap")(self._reset_background_colormap)
         hheader.registerAction("Formatter>Set text formatter")(self._set_text_formatter_with_dialog)
+        hheader.registerAction("Formatter>Reset text formatter")(self._reset_text_formatter)
         hheader.addSeparator()
 
         self.registerAction("Copy")(lambda index: self.copyToClipboard(headers=False))
@@ -592,7 +593,7 @@ class QBaseTable(QtW.QSplitter, QActionRegistry[Tuple[int, int]]):
             self.setTextFormatter(column_name, fmt)
         return None
 
-    def _reset_text_formatter_with_dialog(self, index: int) -> None:
+    def _reset_text_formatter(self, index: int) -> None:
         column_name = self._filtered_columns[index]
         return self.setTextFormatter(column_name, None)
 

--- a/tabulous/_qt/_table/_base/_table_base.py
+++ b/tabulous/_qt/_table/_base/_table_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, TYPE_CHECKING, Tuple
+from typing import Any, Callable, TYPE_CHECKING, Tuple, TypeVar
 import warnings
 from qtpy import QtWidgets as QtW, QtGui, QtCore
 from qtpy.QtCore import Signal, Qt
@@ -1078,13 +1078,17 @@ def _selection_to_literal(sel: tuple[slice, slice]) -> str:
     return txt
 
 
+_V = TypeVar("_V")
+
+
 def _convert_value(
     r: int,
     c: int,
-    x: Any,
-    validator: Callable[[Any], bool],
-    converter: Callable[[int, int, Any], Any],
-) -> Any:
+    x: str,
+    validator: Callable[[_V], bool],
+    converter: Callable[[int, int, str], _V],
+) -> _V:
     """Convert value with validation."""
-    validator(x)  # Raise error if invalid
-    return converter(r, c, x)
+    val = converter(r, c, x)  # convert value first
+    validator(val)  # Raise error if invalid
+    return val

--- a/tabulous/_qt/_table/_base/_text_formatter.py
+++ b/tabulous/_qt/_table/_base/_text_formatter.py
@@ -111,7 +111,7 @@ class QIntFormatterDialog(_QNumberFormatterDialog):
 
         n = self._ndigits.value()
         if val == NumberFormat.default:
-            fmt = "default"
+            fmt = None
         elif val == NumberFormat.decimal:
             fmt = "{}"
         elif val == NumberFormat.exponential:
@@ -137,7 +137,7 @@ class QFloatFormatterDialog(_QNumberFormatterDialog):
 
         n = self._ndigits.value()
         if val == NumberFormat.default:
-            fmt = "default"
+            fmt = None
         elif val == NumberFormat.decimal:
             fmt = f"{{:.{n}f}}"
         elif val == NumberFormat.exponential:
@@ -175,14 +175,14 @@ class QComplexFormatterDialog(_QFormatterDialog):
         self._preview_table.text_formatter(self._name, self.toFormatter(val))
         return self._preview_table.refresh()
 
-    def toFormatter(self, val=None) -> str | Callable[[complex], str]:
+    def toFormatter(self, val=None) -> None | Callable[[complex], str]:
         """Convert widget paramters to a formatter text."""
         if val is None:
             val = self._btns.value
         iunit = self._iunit.text()
         n = self._ndigits.value()
         if val == ComplexFormat.default:
-            return "default"
+            return None
         elif val == ComplexFormat.decimal:
             return lambda x: f"{x.real:.{n}f}{x.imag:+.{n}f}{iunit}"
         elif val == ComplexFormat.exponential:

--- a/tabulous/_qt/_table/_base/_text_formatter.py
+++ b/tabulous/_qt/_table/_base/_text_formatter.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+from typing import Callable
+from enum import Enum, auto
+from qtpy import QtWidgets as QtW
+import numpy as np
+import pandas as pd
+from magicgui.widgets import RadioButtons
+
+from ....widgets import Table
+
+
+class NumberFormat(Enum):
+    """Formats used for real numbers."""
+
+    default = auto()
+    decimal = auto()
+    exponential = auto()
+
+
+class ComplexFormat(Enum):
+    """Formats used for complex numbers."""
+
+    default = auto()
+    decimal = auto()
+    exponential = auto()
+    polar = auto()
+
+
+class TimedeltaFormat(Enum):
+    """Formats used for timedelta."""
+
+    default = auto()
+    day = auto()
+    hour = auto()
+    minute = auto()
+    second = auto()
+
+
+class _QFormatterDialog(QtW.QDialog):
+    def __init__(self, ds: pd.Series, parent: QtW.QWidget | None = None) -> None:
+        super().__init__(parent)
+        _layout = QtW.QHBoxLayout()
+        self._name = ds.name
+        self._preview_table = Table(ds, editable=False)
+        self._preview_table.native.setMaximumWidth(120)
+        self._left_panel = QtW.QWidget()
+        self._left_panel.setLayout(QtW.QVBoxLayout())
+        self._left_panel.layout().setContentsMargins(0, 0, 0, 0)
+
+        _layout.addWidget(self._left_panel)
+        _layout.addWidget(self._preview_table.native)
+        self._init()
+        self.setLayout(_layout)
+        btnbox = QtW.QDialogButtonBox(
+            QtW.QDialogButtonBox.StandardButton.Ok
+            | QtW.QDialogButtonBox.StandardButton.Cancel,
+        )
+        btnbox.accepted.connect(self.accept)
+        btnbox.rejected.connect(self.reject)
+        self.addWidget(btnbox)
+        self.resize(450, 320)
+
+    def _init(self):
+        """Initialize UI."""
+
+    def addWidget(self, widget: QtW.QWidget):
+        self._left_panel.layout().addWidget(widget)
+        return None
+
+    def toFormatter(self, val=None) -> str:
+        """Convert widget paramters to a formatter text."""
+        raise NotImplementedError()
+
+
+class _QNumberFormatterDialog(_QFormatterDialog):
+    def _init(self) -> None:
+        btns = RadioButtons(choices=NumberFormat, value=NumberFormat.default)
+        self._btns = btns
+        self.addWidget(btns.native)
+
+        self._ndigits = QtW.QSpinBox()
+        self._ndigits.setMinimum(1)
+        self._ndigits.setMaximum(12)
+        self._ndigits.setValue(4)
+        self._ndigits.setSuffix(" digits")
+        self.addWidget(self._ndigits)
+
+        btns.changed.connect(self._on_choice_changed)
+        self._ndigits.valueChanged.connect(lambda: self._on_choice_changed())
+
+    def _on_choice_changed(self, val=None):
+        raise NotImplementedError()
+
+
+class QIntFormatterDialog(_QNumberFormatterDialog):
+    def _on_choice_changed(self, val=None):
+        if val is None:
+            val = self._btns.value
+        val = NumberFormat(val)
+        self._ndigits.setVisible(val == NumberFormat.exponential)
+        self._preview_table.text_formatter(self._name, self.toFormatter(val))
+        return self._preview_table.refresh()
+
+    def toFormatter(self, val=None) -> str:
+        """Convert widget paramters to a formatter text."""
+        if val is None:
+            val = self._btns.value
+
+        n = self._ndigits.value()
+        if val == NumberFormat.default:
+            fmt = "default"
+        elif val == NumberFormat.decimal:
+            fmt = "{}"
+        elif val == NumberFormat.exponential:
+            fmt = f"{{:.{n}g}}"
+        else:
+            raise RuntimeError()
+        return fmt
+
+
+class QFloatFormatterDialog(_QNumberFormatterDialog):
+    def _on_choice_changed(self, val=None):
+        if val is None:
+            val = self._btns.value
+        val = NumberFormat(val)
+        self._ndigits.setVisible(val != NumberFormat.default)
+        self._preview_table.text_formatter(self._name, self.toFormatter(val))
+        return self._preview_table.refresh()
+
+    def toFormatter(self, val=None) -> str:
+        """Convert widget paramters to a formatter text."""
+        if val is None:
+            val = self._btns.value
+
+        n = self._ndigits.value()
+        if val == NumberFormat.default:
+            fmt = "default"
+        elif val == NumberFormat.decimal:
+            fmt = f"{{:.{n}f}}"
+        elif val == NumberFormat.exponential:
+            fmt = f"{{:.{n}g}}"
+        else:
+            raise RuntimeError()
+        return fmt
+
+
+class QComplexFormatterDialog(_QFormatterDialog):
+    def _init(self) -> None:
+        btns = RadioButtons(choices=ComplexFormat, value=ComplexFormat.default)
+        self._btns = btns
+        self.addWidget(btns.native)
+
+        self._ndigits = QtW.QSpinBox()
+        self._ndigits.setMinimum(1)
+        self._ndigits.setMaximum(12)
+        self._ndigits.setValue(4)
+        self._ndigits.setSuffix(" digits")
+        self.addWidget(self._ndigits)
+
+        self._iunit = QtW.QLineEdit("j")
+        self.addWidget(self._iunit)
+
+        btns.changed.connect(self._on_choice_changed)
+        self._ndigits.valueChanged.connect(lambda: self._on_choice_changed())
+        self._iunit.textChanged.connect(lambda: self._on_choice_changed())
+
+    def _on_choice_changed(self, val=None):
+        if val is None:
+            val = self._btns.value
+        val = ComplexFormat(val)
+        self._ndigits.setVisible(val != ComplexFormat.default)
+        self._preview_table.text_formatter(self._name, self.toFormatter(val))
+        return self._preview_table.refresh()
+
+    def toFormatter(self, val=None) -> str | Callable[[complex], str]:
+        """Convert widget paramters to a formatter text."""
+        if val is None:
+            val = self._btns.value
+        iunit = self._iunit.text()
+        n = self._ndigits.value()
+        if val == ComplexFormat.default:
+            fmt = "default"
+        elif val == ComplexFormat.decimal:
+            fmt = lambda x: f"{x.real:.{n}f}{x.imag:+.{n}f}{iunit}"
+        elif val == ComplexFormat.exponential:
+            fmt = lambda x: f"{x.real:.{n}e}{x.imag:+.{n}e}{iunit}"
+        elif val == ComplexFormat.polar:
+            fmt = lambda x: f"{abs(x)}exp({np.angle(x):+.{n}f}{iunit})"
+        else:
+            raise RuntimeError()
+        return fmt
+
+
+class QBoolFormatterDialog(_QFormatterDialog):
+    def _init(self) -> None:
+        self._true = QtW.QLineEdit("True")
+        self._false = QtW.QLineEdit("False")
+        self._true.textChanged.connect(self._on_text_changed)
+        self._false.textChanged.connect(self._on_text_changed)
+        self.addWidget(self._true)
+        self.addWidget(self._false)
+
+    def _on_text_changed(self, val=None):
+        return self._preview_table.text_formatter(self._name, self.toFormatter(val))
+
+    def toFormatter(self, val=None) -> Callable[[bool], str]:
+        """Convert widget paramters to a formatter text."""
+        return lambda x: self._true.text() if x else self._false.text()
+
+
+class QDateTimeFormatterDialog(_QFormatterDialog):
+    def _init(self) -> None:
+        label = QtW.QLabel(
+            "%Y: year\n"
+            "%m: month\n"
+            "%d: day\n"
+            "%H: hour\n"
+            "%M: minute\n"
+            "%S: second\n"
+        )
+        self._fmt = QtW.QLineEdit("%Y-%m-%d")
+        self.addWidget(label)
+        self.addWidget(self._fmt)
+        self._fmt.textChanged.connect(self._on_text_changed)
+
+    def _on_text_changed(self, val=None):
+        return self._preview_table.text_formatter(self._name, self.toFormatter(val))
+
+    def toFormatter(self, val: str = None) -> Callable[[bool], str]:
+        """Convert widget paramters to a formatter text."""
+        if val is None:
+            val = self._fmt.text()
+
+        def _fmt(ts: pd.Timestamp):
+            return ts.strftime(val)
+
+        return _fmt
+
+
+class QTimeDeltaFormatterDialog(_QFormatterDialog):
+    def _init(self) -> None:
+        self._btns = RadioButtons(
+            choices=TimedeltaFormat, value=TimedeltaFormat.default
+        )
+        self.addWidget(self._btns.native)
+        self._btns.changed.connect(lambda: self._on_choice_changed())
+
+    def _on_choice_changed(self, val=None):
+        return self._preview_table.text_formatter(self._name, self.toFormatter(val))
+
+    def toFormatter(self, val: str = None) -> Callable[[pd.Timedelta], str]:
+        """Convert widget paramters to a formatter text."""
+        if val is None:
+            val = self._btns.value
+        val = TimedeltaFormat(val)
+
+        if val == TimedeltaFormat.default:
+            return lambda td: str(td)
+        elif val == TimedeltaFormat.day:
+            return lambda td: f"{td.days} days"
+        elif val == TimedeltaFormat.hour:
+            return lambda td: f"{td.total_seconds() // 3600} h"
+        elif val == TimedeltaFormat.minute:
+            return lambda td: f"{td.total_seconds() // 60} min"
+        elif val == TimedeltaFormat.second:
+            return lambda td: f"{td.total_seconds()} s"
+        else:
+            raise RuntimeError()
+
+
+def exec_formatter_dialog(ds: pd.Series, parent=None):
+    dtype = ds.dtype
+    if dtype.kind in "ui":
+        dlg = QIntFormatterDialog(ds, parent=parent)
+    elif dtype.kind == "f":
+        dlg = QFloatFormatterDialog(ds, parent=parent)
+    elif dtype.kind == "b":
+        dlg = QBoolFormatterDialog(ds, parent=parent)
+    elif dtype.kind == "c":
+        dlg = QComplexFormatterDialog(ds, parent=parent)
+    elif dtype.kind == "M":
+        dlg = QDateTimeFormatterDialog(ds, parent=parent)
+    elif dtype.kind == "m":
+        dlg = QTimeDeltaFormatterDialog(ds, parent=parent)
+    else:
+        raise ValueError(f"Dtype {dtype.name} is not supported.")
+
+    if dlg.exec():
+        return dlg.toFormatter()
+    return None

--- a/tabulous/_qt/_table/_base/_text_formatter.py
+++ b/tabulous/_qt/_table/_base/_text_formatter.py
@@ -185,7 +185,7 @@ class QComplexFormatterDialog(_QFormatterDialog):
         elif val == ComplexFormat.exponential:
             fmt = lambda x: f"{x.real:.{n}e}{x.imag:+.{n}e}{iunit}"
         elif val == ComplexFormat.polar:
-            fmt = lambda x: f"{abs(x)}exp({np.angle(x):+.{n}f}{iunit})"
+            fmt = lambda x: f"{abs(x):.{n}f}e^({np.angle(x):+.{n}f}{iunit})"
         else:
             raise RuntimeError()
         return fmt

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -154,9 +154,9 @@ class QSpreadSheet(QMutableSimpleTable):
         """Convert value to the type of the table."""
         return value
 
-    def readClipBoard(self):
+    def readClipBoard(self, sep=r"\s+"):
         """Read clipboard as a string data frame."""
-        return pd.read_clipboard(header=None, dtype="string")  # read as string
+        return pd.read_clipboard(header=None, sep=sep, dtype="string")  # read as string
 
     def setDataFrameValue(self, r: int | slice, c: int | slice, value: Any) -> None:
         nr, nc = self._data_raw.shape

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -318,8 +318,7 @@ class QSpreadSheet(QMutableSimpleTable):
         model = self.model()
         for index in range(column, column + count):
             colname = model.df.columns[index]
-            model._background_colormap.pop(colname, None)
-            model._foreground_colormap.pop(colname, None)
+            model.delete_column(colname)
             self._columns_dtype.pop(colname, None)
 
         self._data_raw = pd.concat(
@@ -461,10 +460,10 @@ class QSpreadSheet(QMutableSimpleTable):
         super()._install_actions()
         return None
 
-    def _set_forground_colormap(self, index: int):
+    def _set_background_colormap_with_dialog(self, index: int):
         return self._set_colormap(index, self.model()._foreground_colormap)
 
-    def _set_background_colormap(self, index: int):
+    def _set_background_colormap_with_dialog(self, index: int):
         return self._set_colormap(index, self.model()._background_colormap)
 
     def _set_colormap(self, index, colormap_dict: dict):

--- a/tabulous/_qt/_table_stack/_finder.py
+++ b/tabulous/_qt/_table_stack/_finder.py
@@ -146,7 +146,8 @@ class QFinderWidget(QtW.QWidget):
             return
         qtable = self.currentTable()
         r, c = self._current_index
-        value = qtable.convertValue(r, c, self._replace_box.text())
+        convert_value = qtable._get_converter(c)
+        value = convert_value(r, c, self._replace_box.text())
         qtable.setDataFrameValue(r, c, value)
         return self.findNext()
 

--- a/tabulous/_qt/_table_stack/_finder.py
+++ b/tabulous/_qt/_table_stack/_finder.py
@@ -210,8 +210,7 @@ class QFinderWidget(QtW.QWidget):
     def _text_match(self, qtable: QBaseTable, r: int, c: int, item, text: str) -> bool:
         model = qtable.model()
         index = model.index(r, c)
-        data = qtable.model().data(index, Qt.ItemDataRole.DisplayRole)
-        displayed_text = qtable.itemDelegate()._format_number(data)
+        displayed_text = qtable.model().data(index, Qt.ItemDataRole.DisplayRole)
         return displayed_text == text
 
     def _text_partial_match(

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Callable, TYPE_CHECKING, Hashable
+from typing import Any, Callable, TYPE_CHECKING, Hashable, Union, Literal
 from psygnal import SignalGroup, Signal
 
 from .filtering import FilterProxy
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from ..color import ColorType
 
     ColorMapping = Callable[[Any], ColorType]
+    Formatter = Union[Callable[[Any], str], Literal["default"], str]
 
 
 class TableSignals(SignalGroup):
@@ -282,6 +283,20 @@ class TableBase(ABC):
             return f
 
         return _wrapper(colormap) if colormap is not None else _wrapper
+
+    def text_formatter(
+        self,
+        column_name: Hashable,
+        /,
+        formatter: Formatter | None = None,
+    ):
+        def _wrapper(f: Formatter) -> Formatter:
+            if f == "default":
+                f = None
+            self._qwidget.setTextFormatter(column_name, f)
+            return f
+
+        return _wrapper(formatter) if formatter is not None else _wrapper
 
     @property
     def view_mode(self) -> str:

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Callable, Hashable, TYPE_CHECKING, Union
+from typing import Any, Callable, Hashable, TYPE_CHECKING, Mapping, Union
 from psygnal import SignalGroup, Signal
 
 from .filtering import FilterProxy
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
     from ..color import ColorType
 
-    ColorMapping = Callable[[Any], ColorType]
+    ColorMapping = Union[Callable[[Any], ColorType], Mapping[Hashable, ColorType]]
     Formatter = Union[Callable[[Any], str], str, None]
     Validator = Callable[[Any], None]
 
@@ -254,7 +254,12 @@ class TableBase(ABC):
             self._qwidget.setForegroundColormap(column_name, f)
             return f
 
-        return _wrapper(colormap) if colormap is not _Void else _wrapper
+        if isinstance(colormap, Mapping):
+            return _wrapper(lambda x: colormap.get(x, None))
+        elif colormap is _Void:
+            return _wrapper
+        else:
+            return _wrapper(colormap)
 
     def background_colormap(
         self,
@@ -278,7 +283,12 @@ class TableBase(ABC):
             self._qwidget.setBackgroundColormap(column_name, f)
             return f
 
-        return _wrapper(colormap) if colormap is not _Void else _wrapper
+        if isinstance(colormap, Mapping):
+            return _wrapper(lambda x: colormap.get(x, None))
+        elif colormap is _Void:
+            return _wrapper
+        else:
+            return _wrapper(colormap)
 
     def text_formatter(
         self,

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Callable, TYPE_CHECKING, Hashable, Union, Literal
+from typing import Any, Callable, Hashable, TYPE_CHECKING, Union
 from psygnal import SignalGroup, Signal
 
 from .filtering import FilterProxy
@@ -34,8 +34,10 @@ if TYPE_CHECKING:
     from ..color import ColorType
 
     ColorMapping = Callable[[Any], ColorType]
-    Formatter = Union[Callable[[Any], str], Literal["default"], str]
-    Validator = Callable[[Any], bool]
+    Formatter = Union[Callable[[Any], str], str, None]
+    Validator = Callable[[Any], None]
+
+_Void = object()
 
 
 class TableSignals(SignalGroup):
@@ -234,7 +236,7 @@ class TableBase(ABC):
         self,
         column_name: Hashable,
         /,
-        colormap: ColorMapping | None = None,
+        colormap: ColorMapping | None = _Void,
     ):
         """
         Set foreground color rule.
@@ -243,23 +245,22 @@ class TableBase(ABC):
         ----------
         column_name : Hashable
             Target column name.
-        colormap : callable, optional
-            colormap function. Must return a color-like object.
+        colormap : callable or None, optional
+            Colormap function. Must return a color-like object. Pass None to reset
+            the colormap.
         """
 
         def _wrapper(f: ColorMapping) -> ColorMapping:
-            if f == "default":
-                f = None
             self._qwidget.setForegroundColormap(column_name, f)
             return f
 
-        return _wrapper(colormap) if colormap is not None else _wrapper
+        return _wrapper(colormap) if colormap is not _Void else _wrapper
 
     def background_colormap(
         self,
         column_name: Hashable,
         /,
-        colormap: ColorMapping | None = None,
+        colormap: ColorMapping | None = _Void,
     ):
         """
         Set background color rule.
@@ -268,23 +269,22 @@ class TableBase(ABC):
         ----------
         column_name : Hashable
             Target column name.
-        colormap : callable, optional
-            colormap function. Must return a color-like object.
+        colormap : callable or None, optional
+            Colormap function. Must return a color-like object. Pass None to reset
+            the colormap.
         """
 
         def _wrapper(f: ColorMapping) -> ColorMapping:
-            if f == "default":
-                f = None
             self._qwidget.setBackgroundColormap(column_name, f)
             return f
 
-        return _wrapper(colormap) if colormap is not None else _wrapper
+        return _wrapper(colormap) if colormap is not _Void else _wrapper
 
     def text_formatter(
         self,
         column_name: Hashable,
         /,
-        formatter: Formatter | None = None,
+        formatter: Formatter | None = _Void,
     ):
         """
         Set background color rule.
@@ -294,22 +294,20 @@ class TableBase(ABC):
         column_name : Hashable
             Target column name.
         formatter : callable, optional
-            formatter function.
+            Formatter function. Pass None to reset the formatter.
         """
 
         def _wrapper(f: Formatter) -> Formatter:
-            if f == "default":
-                f = None
             self._qwidget.setTextFormatter(column_name, f)
             return f
 
-        return _wrapper(formatter) if formatter is not None else _wrapper
+        return _wrapper(formatter) if formatter is not _Void else _wrapper
 
     def validator(
         self,
         column_name: Hashable,
         /,
-        validator: Validator | None = None,
+        validator: Validator | None = _Void,
     ):
         """
         Set background color rule.
@@ -318,17 +316,15 @@ class TableBase(ABC):
         ----------
         column_name : Hashable
             Target column name.
-        validator : callable, optional
-            Validator function.
+        validator : callable or None, optional
+            Validator function. Pass None to reset the validator.
         """
 
         def _wrapper(f: Validator) -> Validator:
-            if f == "default":
-                f = None
             self._qwidget.setDataValidator(column_name, f)
             return f
 
-        return _wrapper(validator) if validator is not None else _wrapper
+        return _wrapper(validator) if validator is not _Void else _wrapper
 
     @property
     def view_mode(self) -> str:

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
     ColorMapping = Callable[[Any], ColorType]
     Formatter = Union[Callable[[Any], str], Literal["default"], str]
+    Validator = Callable[[Any], bool]
 
 
 class TableSignals(SignalGroup):
@@ -153,15 +154,6 @@ class TableBase(ABC):
         return self._qwidget._keymap
 
     @property
-    def precision(self) -> int:
-        """Precision (displayed digits) of table."""
-        return self._qwidget.precision()
-
-    @precision.setter
-    def precision(self, value: int) -> None:
-        return self._qwidget.setPrecision(value)
-
-    @property
     def metadata(self) -> dict[str, Any]:
         return self._metadata
 
@@ -256,6 +248,8 @@ class TableBase(ABC):
         """
 
         def _wrapper(f: ColorMapping) -> ColorMapping:
+            if f == "default":
+                f = None
             self._qwidget.setForegroundColormap(column_name, f)
             return f
 
@@ -279,6 +273,8 @@ class TableBase(ABC):
         """
 
         def _wrapper(f: ColorMapping) -> ColorMapping:
+            if f == "default":
+                f = None
             self._qwidget.setBackgroundColormap(column_name, f)
             return f
 
@@ -290,6 +286,17 @@ class TableBase(ABC):
         /,
         formatter: Formatter | None = None,
     ):
+        """
+        Set background color rule.
+
+        Parameters
+        ----------
+        column_name : Hashable
+            Target column name.
+        formatter : callable, optional
+            formatter function.
+        """
+
         def _wrapper(f: Formatter) -> Formatter:
             if f == "default":
                 f = None
@@ -297,6 +304,31 @@ class TableBase(ABC):
             return f
 
         return _wrapper(formatter) if formatter is not None else _wrapper
+
+    def validator(
+        self,
+        column_name: Hashable,
+        /,
+        validator: Validator | None = None,
+    ):
+        """
+        Set background color rule.
+
+        Parameters
+        ----------
+        column_name : Hashable
+            Target column name.
+        validator : callable, optional
+            Validator function.
+        """
+
+        def _wrapper(f: Validator) -> Validator:
+            if f == "default":
+                f = None
+            self._qwidget.setDataValidator(column_name, f)
+            return f
+
+        return _wrapper(validator) if validator is not None else _wrapper
 
     @property
     def view_mode(self) -> str:

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -2,6 +2,7 @@ from tabulous import TableViewer
 from tabulous.widgets import TableBase
 from tabulous._qt._table import QBaseTable
 from tabulous._qt._table_stack._tabwidget import QTabbedTableStack
+from qtpy.QtCore import Qt
 
 def get_tabwidget_tab_name(viewer: TableViewer, i: int) -> str:
     qtablist: QTabbedTableStack = viewer._qwidget._tablestack
@@ -10,6 +11,14 @@ def get_tabwidget_tab_name(viewer: TableViewer, i: int) -> str:
 def get_cell_value(table: QBaseTable, row, col) -> str:
     index = table.model().index(row, col)
     return table.model().data(index)
+
+def get_cell_foreground_color(table: QBaseTable, row, col) -> str:
+    index = table.model().index(row, col)
+    return table.model().data(index, Qt.ItemDataRole.ForegroundRole)
+
+def get_cell_background_color(table: QBaseTable, row, col) -> str:
+    index = table.model().index(row, col)
+    return table.model().data(index, Qt.ItemDataRole.BackgroundRole)
 
 def edit_cell(table: QBaseTable, row, col, value):
     table.model().dataEdited.emit(row, col, value)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -7,7 +7,7 @@ def get_tabwidget_tab_name(viewer: TableViewer, i: int) -> str:
     qtablist: QTabbedTableStack = viewer._qwidget._tablestack
     return qtablist.tabText(i)
 
-def get_cell_value(table: QBaseTable, row, col):
+def get_cell_value(table: QBaseTable, row, col) -> str:
     index = table.model().index(row, col)
     return table.model().data(index)
 

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,0 +1,53 @@
+from tabulous import TableViewer
+from qtpy.QtGui import QColor
+from . import _utils
+
+cmap = {
+    "a": [255, 0, 0, 255],
+    "b": [0, 255, 0, 255],
+    "c": [0, 0, 255, 255],
+}
+
+def _cmap_func(x):
+    return cmap[x]
+
+def test_foreground():
+    viewer = TableViewer(show=False)
+    table = viewer.add_table({"char": ["a", "b", "c"]})
+    default_color = _utils.get_cell_foreground_color(table.native, 0, 0)
+
+    table.foreground_colormap("char", cmap)
+    assert _utils.get_cell_foreground_color(table.native, 0, 0) == QColor(*cmap["a"])
+    assert _utils.get_cell_foreground_color(table.native, 1, 0) == QColor(*cmap["b"])
+    assert _utils.get_cell_foreground_color(table.native, 2, 0) == QColor(*cmap["c"])
+
+    table.foreground_colormap("char", None)
+    assert _utils.get_cell_foreground_color(table.native, 0, 0) == default_color
+    assert _utils.get_cell_foreground_color(table.native, 1, 0) == default_color
+    assert _utils.get_cell_foreground_color(table.native, 2, 0) == default_color
+
+    table.foreground_colormap("char", _cmap_func)
+    assert _utils.get_cell_foreground_color(table.native, 0, 0) == QColor(*cmap["a"])
+    assert _utils.get_cell_foreground_color(table.native, 1, 0) == QColor(*cmap["b"])
+    assert _utils.get_cell_foreground_color(table.native, 2, 0) == QColor(*cmap["c"])
+
+
+def test_background():
+    viewer = TableViewer(show=False)
+    table = viewer.add_table({"char": ["a", "b", "c"]})
+    default_color = _utils.get_cell_background_color(table.native, 0, 0)
+
+    table.background_colormap("char", cmap)
+    assert _utils.get_cell_background_color(table.native, 0, 0) == QColor(*cmap["a"])
+    assert _utils.get_cell_background_color(table.native, 1, 0) == QColor(*cmap["b"])
+    assert _utils.get_cell_background_color(table.native, 2, 0) == QColor(*cmap["c"])
+
+    table.background_colormap("char", None)
+    assert _utils.get_cell_background_color(table.native, 0, 0) == default_color
+    assert _utils.get_cell_background_color(table.native, 1, 0) == default_color
+    assert _utils.get_cell_background_color(table.native, 2, 0) == default_color
+
+    table.background_colormap("char", _cmap_func)
+    assert _utils.get_cell_background_color(table.native, 0, 0) == QColor(*cmap["a"])
+    assert _utils.get_cell_background_color(table.native, 1, 0) == QColor(*cmap["b"])
+    assert _utils.get_cell_background_color(table.native, 2, 0) == QColor(*cmap["c"])

--- a/tests/test_text_formatter.py
+++ b/tests/test_text_formatter.py
@@ -1,0 +1,16 @@
+from tabulous import TableViewer
+from . import _utils
+
+def test_text_formatter():
+    viewer = TableViewer(show=False)
+    table = viewer.add_table({"number": [1, 2, 3], "char": ["a", "b", "c"]})
+    assert _utils.get_cell_value(table.native, 0, 0) == "1"
+
+    # set formatter
+    table.text_formatter("number", lambda x: str(x) + "!")
+    assert _utils.get_cell_value(table.native, 0, 0) == "1!"
+    assert _utils.get_cell_value(table.native, 0, 1) == "a"
+
+    # reset formatter
+    table.text_formatter("number", None)
+    assert _utils.get_cell_value(table.native, 0, 0) == "1"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,47 @@
+from tabulous import TableViewer
+import pandas as pd
+from pandas.testing import assert_frame_equal
+import pytest
+
+def test_validator():
+    viewer = TableViewer(show=False)
+    table = viewer.add_table(
+        {"number": [1, 2, 3], "char": ["a", "b", "c"]},
+        editable=True,
+    )
+    @table.validator("number")
+    def _validator(x):
+        if x < 0:
+            raise ValueError("Negative numbers are not allowed")
+
+    table.cell[0, 0] = 2  # no error
+    assert table.cell[0, 0] == 2
+
+    # validation error
+    with pytest.raises(ValueError):
+        table.cell[0, 0] = -1
+    assert table.cell[0, 0] == 2
+
+def test_validator_on_paste():
+    viewer = TableViewer(show=False)
+    table = viewer.add_table(
+        {"a": [1, 2, 3], "b": [1, 2, 3]},
+        editable=True,
+    )
+
+    @table.validator("a")
+    @table.validator("b")
+    def _validator(x):
+        if x < 0:
+            raise ValueError("Negative numbers are not allowed")
+
+    df = pd.DataFrame({"a": [1, 3, 1], "b": [1, 3, 1]})
+    df.to_clipboard(index=False, header=False)
+    viewer.paste_data([(slice(None), slice(None))])
+    assert_frame_equal(table.data, df)
+
+    df_err = pd.DataFrame({"a": [1, 1, 1], "b": [1, -1, 1]})
+    df_err.to_clipboard(index=False, header=False)
+    with pytest.raises(ValueError):
+        viewer.paste_data([(slice(None), slice(None))])
+    assert_frame_equal(table.data, df)  # don't change data


### PR DESCRIPTION
Text formatter was not customizable and had many problems (especially, floating values).

- [x] Stop using `displayText` in item delegate.
- [x] Define API for custom formatter.
- [x] Make user interface for adding formatters that are usually useful.