### PR TITLE
Updates in nan value and errors

### DIFF
--- a/tabulous/_eval/_graph.py
+++ b/tabulous/_eval/_graph.py
@@ -86,13 +86,18 @@ class Graph:
         if not self._callback_blocked:
             with self.blocked():
                 out = self._func()
-                if (e := out.get_err()) and (sl := self._func.last_destination):
+                if out.get_err() and (sl := self._func.last_destination):
                     import pandas as pd
 
                     rsl, csl = sl
+                    # determine the error object
+                    if table.table_type == "SpreadSheet":
+                        err_repr = "#ERROR"
+                    else:
+                        err_repr = pd.NA
                     val = np.full(
                         (rsl.stop - rsl.start, csl.stop - csl.start),
-                        repr(e),
+                        err_repr,
                         dtype=object,
                     )
                     qtable_view = self.table._qwidget._qtable_view

--- a/tabulous/_qt/_table/_spreadsheet.py
+++ b/tabulous/_qt/_table/_spreadsheet.py
@@ -166,6 +166,7 @@ class QSpreadSheet(QMutableSimpleTable):
                 buf,
                 sep=_sep,
                 header=0,
+                na_values=["#ERROR"],
                 names=data_raw.columns,
                 **self._columns_dtype.as_pandas_kwargs(),
             )

--- a/tabulous/_qt/_table_stack/_tabwidget.py
+++ b/tabulous/_qt/_table_stack/_tabwidget.py
@@ -4,17 +4,17 @@ import weakref
 from qtpy import QtWidgets as QtW, QtGui, QtCore
 from qtpy.QtCore import Qt, Signal
 
-from ._start import QStartupWidget
-from ._utils import create_temporal_line_edit
+from tabulous._qt._table_stack._start import QStartupWidget
+from tabulous._qt._table_stack._utils import create_temporal_line_edit
 
-from .._table._base._table_group import QTableGroup
-from .._clickable_label import QClickableLabel
-from .._action_registry import QActionRegistry
+from tabulous._qt._table._base._table_group import QTableGroup
+from tabulous._qt._clickable_label import QClickableLabel
+from tabulous._qt._action_registry import QActionRegistry
 
 if TYPE_CHECKING:
-    from .._table import QBaseTable, QMutableTable
-    from ._overlay import QOverlayWidget
-    from .._mainwindow._base import _QtMainWidgetBase
+    from tabulous._qt._table import QBaseTable, QMutableTable
+    from tabulous._qt._mainwindow._base import _QtMainWidgetBase
+    from tabulous._qt._table_stack._overlay import QOverlayWidget
 
 
 class QTabbedTableStack(QtW.QTabWidget, QActionRegistry[int]):

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -474,7 +474,7 @@ class TableBase(ABC):
                 with qtable_view._selection_model.blocked(), qtable_view._ref_graphs.blocked(
                     *pos
                 ):
-                    qtable.setDataFrameValue(*pos, repr(e))
+                    qtable.setDataFrameValue(*pos, "#ERROR")
                 return None
             # SyntaxError/AttributeError might be caused by mistouching. Don't close
             # the editor.


### PR DESCRIPTION
Using string like "TypeError(...)" to represent cell evaluation error is not type safe. It may change the column dtype. This PR fix it by interpreting "#ERROR" as a nan string.