### PR TITLE
Add post-initialization architecture

### DIFF
--- a/rst/index.rst
+++ b/rst/index.rst
@@ -44,6 +44,7 @@ Other Contents
 .. toctree::
    :maxdepth: 1
 
+   ./main/customize
    ./main/register_action
    ./main/cheat_sheet
    ./apidoc/modules

--- a/rst/main/customize.rst
+++ b/rst/main/customize.rst
@@ -2,8 +2,6 @@
 Customize Viewer Actions
 ========================
 
-.. versionadded:: 0.4.1
-
 :mod:`tabulous` settings and configuration are stored in the user directory.
 Configuration files will be created automatically when the viewer is launched
 for the first time.
@@ -56,11 +54,10 @@ The "config.toml" file describes the basic settings of the viewer.
 Edit post_init.py
 =================
 
+.. versionadded:: 0.4.1
+
 The "post_init.py" file is used to customize contextmenus, keybindings, namespaces
 and commands of the viewer.
-
-Initializers Objects
---------------------
 
 Two initializer objects are used to register variables and functions to the
 application *before* it is actually launched.
@@ -72,13 +69,67 @@ application *before* it is actually launched.
 
     viewer, table = get_initializers()
 
-Each initializer object has similar attributes as the :class:`TableViewer`` and
-:class:`Table` respectively, as described in :doc:`register_action`.
+Each initializer object has similar attributes as the :class:`TableViewer` and
+:class:`Table` respectively.
 
-1. Register right-click contextmenu Actions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. Contextmenu registration
+    See :doc:`register_action` for what viewer/table components support the
+    registration.
+
+    - :meth:`viewer.tables.register` ... register action to the tab bar.
+    - :meth:`table.index.register` ... register action to the vertical header.
+    - :meth:`table.columns.register` ... register action to the horizontal header.
+    - :meth:`table.cells.register` ... register action to the table cells.
+    - :meth:`viewer.commands.register` ... register command to the console.
+    - :meth:`viewer.keymap.register` ... register keybinding to the viewer.
+    - :meth:`table.keymap.register` ... register keybinding to each table.
+
+2. Namespace update
+    - :meth:`viewer.cell_namespace.update` ... update the namespace in cells.
+    - :meth:`viewer.console.update` ... update the namespace of the console.
+
+Register actions using :meth:`register` method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Contextmenu, keybindings and commands can be registered using the :meth:`register`
+method are also available for initialization.
 
 .. code-block:: python
 
     # post_init.py
-    viewer.
+
+    @viewer.keymap.register("Ctrl+U")
+    def my_func(viewer):
+        print("Ctrl+U clicked")
+
+    @table.cell.register("Test > Print location")
+    def my_func(table, index):
+        row, column = index
+        print("Cell location: {}, {}".format(row, column))
+
+    @viewer.command_palette.register("Test: Print string")
+    def my_func(viewer):
+        print("Command palette clicked")
+
+Update namespaces
+^^^^^^^^^^^^^^^^^
+
+:attr:`viewer.cell_namespace` and :attr:`viewer.console` supports :meth:`update` and
+:meth:`add` methods to update the namespace.
+
+.. code-block:: python
+
+    # post_init.py
+
+    # use `update` method to update the namespace in a dict-like manner
+    viewer.cell_namespace.update({"my_var": 1})
+    viewer.console.update(pi=3.14159265359)
+
+    # use `add` decorator
+    @viewer.cell_namespace.add
+    def SUM(x):
+        return np.sum(x)
+
+    @viewer.console.add
+    class MyClass:
+        pass

--- a/rst/main/customize.rst
+++ b/rst/main/customize.rst
@@ -2,7 +2,12 @@
 Customize Viewer Actions
 ========================
 
+.. versionadded:: 0.4.1
+
 :mod:`tabulous` settings and configuration are stored in the user directory.
+Configuration files will be created automatically when the viewer is launched
+for the first time.
+
 You can check the location of the user directory by running the following
 command.
 
@@ -10,12 +15,70 @@ command.
 
     $ tabulous --user-dir
 
-Edit config.toml File
-=====================
+Edit config.toml
+================
 
-config.toml
+The "config.toml" file describes the basic settings of the viewer.
 
-Edit post_init.py File
-======================
+.. code-block:: toml
 
-post_init.py
+    [console_namespace]
+    tabulous = ...  # default identifier of the tabulous module
+    viewer = ...  # default identifier of the viewer instance
+    pandas = ...  # default identifier of the pandas module
+    numpy = ...  # default identifier of the numpy module
+    load_startup_file = ...  # load IPython startup file or not
+
+    [table]
+    max_row_count = ...  # maximum number of rows allowed to be added
+    max_column_count = ...  # maximum number of rows allowed to be added
+    font = ...  # font family name
+    font_size = ...   # font size in points
+    row_size = ...  # row height in pixels
+    column_size = ...  # column width in pixels
+
+    [cell]
+    eval_prefix = ...  # prefix of for in-cell evaluation
+    ref_prefix = ...  # prefix of for in-cell evaluation with cell references
+
+    [window]
+    ask_on_close = ...  # ask before closing the window or not
+    show_console = ...  # show console on startup or not
+
+.. note::
+
+    To reset the configuration file to the default, run the following command.
+
+    .. code-block:: bash
+
+        $ tabulous --init-config
+
+Edit post_init.py
+=================
+
+The "post_init.py" file is used to customize contextmenus, keybindings, namespaces
+and commands of the viewer.
+
+Initializers Objects
+--------------------
+
+Two initializer objects are used to register variables and functions to the
+application *before* it is actually launched.
+
+.. code-block:: python
+
+    # post_init.py
+    from tabulous.post_init import get_initializers
+
+    viewer, table = get_initializers()
+
+Each initializer object has similar attributes as the :class:`TableViewer`` and
+:class:`Table` respectively, as described in :doc:`register_action`.
+
+1. Register right-click contextmenu Actions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    # post_init.py
+    viewer.

--- a/rst/main/customize.rst
+++ b/rst/main/customize.rst
@@ -1,0 +1,21 @@
+========================
+Customize Viewer Actions
+========================
+
+:mod:`tabulous` settings and configuration are stored in the user directory.
+You can check the location of the user directory by running the following
+command.
+
+.. code-block:: bash
+
+    $ tabulous --user-dir
+
+Edit config.toml File
+=====================
+
+config.toml
+
+Edit post_init.py File
+======================
+
+post_init.py

--- a/rst/main/quickstart.rst
+++ b/rst/main/quickstart.rst
@@ -234,17 +234,17 @@ to register custom key combo.
 
     # simple key binding
     @viewer.keymap.register("Ctrl+P")
-    def function():
+    def function(viewer):
         """do something"""
 
     # key combo
     @viewer.keymap.register("Ctrl+K, Ctrl+Q")
-    def function():
+    def function(viewer):
         """do something"""
 
     # overwrite an existing key combo
     @viewer.keymap.register("Ctrl+K, Ctrl+Q", overwrite=True)
-    def function():
+    def function(viewer):
         """do something"""
 
 Command palette

--- a/rst/main/quickstart.rst
+++ b/rst/main/quickstart.rst
@@ -227,23 +227,23 @@ Key combo
 All the global key map is listed in a widget that will be shown when you press
 :kbd:`Ctrl+K ⇒ Shift+?` key combo.
 
-:attr:`keymap` is the key map registry object of table viewers. You can use :meth:`bind_key`
+:attr:`keymap` is the key map registry object of table viewers. You can use :meth:`register`
 to register custom key combo.
 
 .. code-block:: python
 
     # simple key binding
-    @viewer.keymap.bind_key("Ctrl+P")
+    @viewer.keymap.register("Ctrl+P")
     def function():
         """do something"""
 
     # key combo
-    @viewer.keymap.bind_key("Ctrl+K, Ctrl+Q")
+    @viewer.keymap.register("Ctrl+K, Ctrl+Q")
     def function():
         """do something"""
 
     # overwrite an existing key combo
-    @viewer.keymap.bind_key("Ctrl+K, Ctrl+Q", overwrite=True)
+    @viewer.keymap.register("Ctrl+K, Ctrl+Q", overwrite=True)
     def function():
         """do something"""
 

--- a/rst/main/register_action.rst
+++ b/rst/main/register_action.rst
@@ -2,7 +2,20 @@
 Register Custom Actions
 =======================
 
-Tabulous viewer has several components that support custom action registration.
+Tabulous viewer has several components that support custom action registration using
+method :meth:`register`. All the :meth:`register` methods will be used as following syntax.
+
+.. code-block:: python
+
+    # viewer specific actions
+    @viewer.XXX.register("<Location description>")
+    def func(viewer):
+        ...
+
+    # table specific actions
+    @table.XXX.register("<Location description>")
+    def func(table):
+        ...
 
 .. contents:: Contents
     :local:
@@ -33,12 +46,16 @@ you can register functions using following methods.
 3. :meth:`table.columns.register` ... register action to the horizontal header.
 4. :meth:`table.cells.register` ... register action to the table cells.
 
+.. warning::
+
+    :meth:`register_action` is deprecated version of :meth:`register` until 0.4.0.
+
 Register actions to the tab bar
 -------------------------------
 
-Action for :meth:`viewer.tables.register` must have signature
-``(viewer, index: int)``. ``viewer`` is the viewer object to which the action is
-registered and ``index`` is the index of the right-clicked tab.
+Action for :meth:`viewer.tables.register` must have signature ``(viewer, index: int)``
+or its shorter version such as ``(viewer)``. ``viewer`` is the viewer object to which
+the action is registered and ``index`` is the index of the right-clicked tab.
 
 .. code-block:: python
 
@@ -60,10 +77,10 @@ If you want to register it at a submenu, use ``">"`` as the separator.
 Register actions to the headers
 -------------------------------
 
-Other :meth:`register` method works similarly. In the case of headers,
-the signature for the action is ``(table, index: int)``. Here, ``table`` is the
-table object to which action is registered and ``index`` is the index of the
-right-clicked position (ready for :meth:`iloc`).
+Other :meth:`register` method works similarly. In the case of headers, the signature
+for the action is ``(table, index: int)`` or its shorter version such as ``(table)``.
+Here, ``table`` is the table object to which action is registered and ``index`` is
+the index of the right-clicked position (ready for :attr:`iloc`).
 
 .. code-block:: python
 
@@ -80,10 +97,10 @@ right-clicked position (ready for :meth:`iloc`).
 Register actions to the cells
 -----------------------------
 
-The :meth:`register` method for cells also work in a similar way, but has
-signature ``(table, index: tuple[int, int])``. Here, ``table`` is the table object
-to which action is registered ``index`` is a tuple of row index and column index
-(ready for :meth:`iloc`).
+The :meth:`register` method for cells also work in a similar way, but has signature
+``(table, index: tuple[int, int])`` or its shorter version such as ``(table)``.
+Here, ``table`` is the table object to which action is registered ``index`` is a
+tuple of row index and column index (ready for :attr:`iloc`).
 
 .. code-block:: python
 
@@ -91,10 +108,11 @@ to which action is registered ``index`` is a tuple of row index and column index
     def func(table: TableBase, index: tuple[int, int]):
         print(table.data.iloc[index])
 
-Custom Keybindings
-==================
+Custom Command in Command Palette
+=================================
 
-Both viewers and tables have :attr:`keymap` attribute for keymap registration.
+:mod:`tabulous` provides a command palette for executing actions. You can register
+your own actions to the command palette using :meth:`register` method.
 
 .. code-block:: python
 
@@ -102,11 +120,38 @@ Both viewers and tables have :attr:`keymap` attribute for keymap registration.
 
     viewer = TableViewer()
 
-    # register function "func" as an action for key "Ctrl+P"
+    # will be register under "User defined" context
+    @viewer.command_palette.register("Print all table names")
+    def func(viewer: TableViewer):
+        for table in viewer.tables:
+            print(table.name)
+
+    # will be register under "Table" context
+    @viewer.command_palette.register("Table: Print current table name")
+    def func(viewer: TableViewer):
+        print(viewer.current_table.name)
+
+
+Custom Keybindings
+==================
+
+Both viewers and tables have :attr:`keymap` attribute for keymap registration.
+
+1. :meth:`viewer.keymap.register` ... register keybindings to the viewer.
+2. :meth:`table.keymap.register` ... register keybindings to each table.
+
+.. code-block:: python
+
+    from tabulous import TableViewer
+
+    viewer = TableViewer()
+
+    # register function "func" as an action for key "Ctrl+U"
     @viewer.keymap.register("Ctrl+U")
     def func(viewer: TableViewer):
         print("Ctrl+U is pressed")
 
+    # register function "func" as an action for key combo "Ctrl+K, Ctrl+U"
     @viewer.keymap.register("Ctrl+K, Ctrl+U")
     def func(viewer: TableViewer):
         print("keycombo Ctrl+K -> Ctrl+U is pressed")

--- a/rst/main/register_action.rst
+++ b/rst/main/register_action.rst
@@ -2,8 +2,23 @@
 Register Custom Actions
 =======================
 
-Tabulous viewer has several components that support custom action registration
-to the context menu. Suppose you have a viewer and a table:
+Tabulous viewer has several components that support custom action registration.
+
+.. contents:: Contents
+    :local:
+    :depth: 2
+
+Custom Contextmenu Actions
+==========================
+
+Currently there are four components that support custom action registration.
+
+1. Tab bar
+2. Vertical header
+3. Horizontal header
+4. Table cells
+
+Suppose you have a viewer and a table:
 
 .. code-block:: python
 
@@ -13,58 +28,85 @@ to the context menu. Suppose you have a viewer and a table:
 
 you can register functions using following methods.
 
-- :meth:`viewer.tables.register_action` ... register action to the tab bar.
-- :meth:`table.index.register_action` ... register action to the vertical header.
-- :meth:`table.columns.register_action` ... register action to the horizontal header.
-- :meth:`table.cells.register_action` ... register action to the table cells.
+1. :meth:`viewer.tables.register` ... register action to the tab bar.
+2. :meth:`table.index.register` ... register action to the vertical header.
+3. :meth:`table.columns.register` ... register action to the horizontal header.
+4. :meth:`table.cells.register` ... register action to the table cells.
 
 Register actions to the tab bar
-===============================
+-------------------------------
 
-Action for :meth:`viewer.tables.register_action` must have signature ``(index: int)``.
-``index`` is the index of the right-clicked tab.
+Action for :meth:`viewer.tables.register` must have signature
+``(viewer, index: int)``. ``viewer`` is the viewer object to which the action is
+registered and ``index`` is the index of the right-clicked tab.
 
 .. code-block:: python
 
+    from tabulous import TableViewerBase
+
     # register function "func" as an action named "Print tab name"
-    @viewer.tables.register_action("Print tab name")
-    def func(index: int):
+    @viewer.tables.register("Print tab name")
+    def func(viewer: TableViewerBase, index: int):
         print(viewer.tables[i].name)
 
 If you want to register it at a submenu, use ``">"`` as the separator.
 
 .. code-block:: python
 
-    @viewer.tables.register_action("Custom menu > Print tab name")
-    def func(index: int):
+    @viewer.tables.register("Custom menu > Print tab name")
+    def func(viewer: TableViewerBase, index: int):
         print(viewer.tables[i].name)
 
 Register actions to the headers
-===============================
+-------------------------------
 
-Other :meth:`register_action` method works similarly. In the case of headers,
-the signature for the action is also ``(index: int)``. Here, ``index`` is
-the index of the right-clicked position (ready for :meth:`iloc`).
+Other :meth:`register` method works similarly. In the case of headers,
+the signature for the action is ``(table, index: int)``. Here, ``table`` is the
+table object to which action is registered and ``index`` is the index of the
+right-clicked position (ready for :meth:`iloc`).
 
 .. code-block:: python
 
-    @table.index.register_action("Print this row")
-    def func(index: int):
+    from tabulous.widgets import TableBase
+
+    @table.index.register("Print this row")
+    def func(table: TableBase, index: int):
         print(table.data.iloc[index, :])
 
-    @table.columns.register_action("Print this column")
-    def func(index: int):
+    @table.columns.register("Print this column")
+    def func(table: TableBase, index: int):
         print(table.data.iloc[:, index])
 
 Register actions to the cells
-=============================
+-----------------------------
 
-The :meth:`register_action` method for cells also work in a similar way, but has
-signature ``(index: tuple[int, int])`` unlike others. Here, ``index`` is a
-tuple of row index and column index (ready for :meth:`iloc`).
+The :meth:`register` method for cells also work in a similar way, but has
+signature ``(table, index: tuple[int, int])``. Here, ``table`` is the table object
+to which action is registered ``index`` is a tuple of row index and column index
+(ready for :meth:`iloc`).
 
 .. code-block:: python
 
-    @table.cell.register_action("Print this value")
-    def func(index: tuple[int, int]):
+    @table.cell.register("Print this value")
+    def func(table: TableBase, index: tuple[int, int]):
         print(table.data.iloc[index])
+
+Custom Keybindings
+==================
+
+Both viewers and tables have :attr:`keymap` attribute for keymap registration.
+
+.. code-block:: python
+
+    from tabulous import TableViewer
+
+    viewer = TableViewer()
+
+    # register function "func" as an action for key "Ctrl+P"
+    @viewer.keymap.register("Ctrl+U")
+    def func(viewer: TableViewer):
+        print("Ctrl+U is pressed")
+
+    @viewer.keymap.register("Ctrl+K, Ctrl+U")
+    def func(viewer: TableViewer):
+        print("keycombo Ctrl+K -> Ctrl+U is pressed")

--- a/tabulous/__main__.py
+++ b/tabulous/__main__.py
@@ -7,6 +7,7 @@ class TabulousArgs(argparse.Namespace):
     """Tabulous specific arguments"""
 
     profile: bool
+    user_dir: bool
     debug: bool
     init_config: bool
     init_history: bool
@@ -27,6 +28,7 @@ class TabulousParser(argparse.ArgumentParser):
             version=f"tabulous version {__version__}",
         )
         self.add_argument("--profile", action="store_true")
+        self.add_argument("--user-dir", action="store_true")
         self.add_argument("--debug", action="store_true")
         self.add_argument("--init-config", action="store_true")
         self.add_argument("--init-history", action="store_true")
@@ -50,7 +52,7 @@ def main():
 
     args, _ = parser.parse_known_args()
 
-    if args.profile:
+    if args.profile or args.user_dir:
         from ._utils import CONFIG_PATH
 
         return print(CONFIG_PATH.parent)

--- a/tabulous/_keymap/_keymap.py
+++ b/tabulous/_keymap/_keymap.py
@@ -170,7 +170,8 @@ class QtKeys:
 
     def _reduce_key(self) -> Self:
         if self.key == ExtKey.No:
-            # this case is needed to avoid triggering parametric key binding with modifiers.
+            # this case is needed to avoid triggering parametric key binding with
+            # modifiers.
             return self
         new = QtKeys(self)
         new.key = ExtKey.Any
@@ -404,7 +405,7 @@ class QtKeyMap(RecursiveMapping[QtKeys, Callable]):
     ) -> _F:
         ...
 
-    def bind(self, key, callback=None, *, overwrite=False, desc=None, **kwargs) -> None:
+    def bind(self, key, callback=None, *, overwrite=False, desc=None, **kwargs):
         """Assign key or key combo to callback."""
 
         def wrapper(func):
@@ -420,6 +421,20 @@ class QtKeyMap(RecursiveMapping[QtKeys, Callable]):
             return func
 
         return wrapper if callback is None else wrapper(callback)
+
+    def unbind(self, key: str) -> None:
+        _key = _normalize_key_combo(key)
+        if isinstance(_key, (str, QtKeys)):
+            del self._current_map[_key]
+        elif isinstance(_key, Sequence):
+            current = self
+            *pref, last = _key
+            for k in pref:
+                current = current[k]
+            del current[last]
+        else:
+            raise TypeError("key must be a string or a sequence of strings")
+        return None
 
     @overload
     def bind_deactivated(
@@ -453,7 +468,8 @@ class QtKeyMap(RecursiveMapping[QtKeys, Callable]):
                 if not isinstance(current, QtKeyMap):
                     seq = _key[:i]
                     raise ValueError(
-                        f"Non keymap object {type(current)} encountered at {', '.join(seq)}."
+                        f"Non keymap object {type(current)} encountered at "
+                        f"{', '.join(seq)}."
                     )
                 k = QtKeys(k)
                 try:
@@ -479,7 +495,8 @@ class QtKeyMap(RecursiveMapping[QtKeys, Callable]):
                 if not isinstance(current, QtKeyMap):
                     seq = _key[:i]
                     raise ValueError(
-                        f"Non keymap object {type(current)} encountered at {', '.join(seq)}."
+                        f"Non keymap object {type(current)} encountered at "
+                        f"{', '.join(seq)}."
                     )
                 k = QtKeys(k)
                 try:

--- a/tabulous/_qt/_action_registry.py
+++ b/tabulous/_qt/_action_registry.py
@@ -55,6 +55,7 @@ class QActionRegistry(QtCore.QObject, Generic[_T]):
             locs = location.split(">")
 
         for loc in locs:
+            loc = loc.strip()
             a = menu.searchChild(loc)
             if a is None:
                 raise ValueError(f"{location} is not a valid location.")

--- a/tabulous/_qt/_action_registry.py
+++ b/tabulous/_qt/_action_registry.py
@@ -46,6 +46,24 @@ class QActionRegistry(QtCore.QObject, Generic[_T]):
 
         return f
 
+    def unregisterAction(self, location: str):
+        locs = location.split(">")
+        menu = self._qt_context_menu
+        for loc in locs[:-1]:
+            loc = loc.strip()
+            a = menu.searchChild(loc)
+            if a is None:
+                menu = menu.addMenu(loc)
+            elif not isinstance(a, QContextMenu):
+                i = locs.index(loc)
+                err_loc = ">".join(locs[:i])
+                raise TypeError(f"{err_loc} is not a menu.")
+            else:
+                menu = a
+        action = menu._actions[loc[-1]]
+        menu.removeAction(action)
+        return None
+
     def addSeparator(self, location: str | None = None):
         """Add separator at the given location."""
         menu = self._qt_context_menu

--- a/tabulous/_qt/_action_registry.py
+++ b/tabulous/_qt/_action_registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Any, Callable, Generic, TypeVar
-from qtpy import QtWidgets as QtW, QtCore, QtGui
+from qtpy import QtWidgets as QtW, QtCore
 from qtpy.QtWidgets import QAction
 
 _T = TypeVar("_T")
@@ -24,11 +24,12 @@ class QActionRegistry(QtCore.QObject, Generic[_T]):
     def __init__(self, *args, **kwargs) -> None:
         self._qt_context_menu = QContextMenu(self)
 
-    def registerAction(self, location: str):
+    def registerAction(self, location: str, f: Callable[[_T], Any]):
         """Register a function to the context menu at the given location."""
         locs = location.split(">")
         menu = self._qt_context_menu
         for loc in locs[:-1]:
+            loc = loc.strip()
             a = menu.searchChild(loc)
             if a is None:
                 menu = menu.addMenu(loc)
@@ -39,13 +40,11 @@ class QActionRegistry(QtCore.QObject, Generic[_T]):
             else:
                 menu = a
 
-        def wrapper(f: Callable[[_T], Any]):
-            action = QAction(locs[-1], self)
-            action.triggered.connect(lambda: f(self._qt_context_menu._current_index))
-            menu.addAction(action)
-            return f
+        action = QAction(locs[-1], self)
+        action.triggered.connect(lambda: f(self._qt_context_menu._current_index))
+        menu.addAction(action)
 
-        return wrapper
+        return f
 
     def addSeparator(self, location: str | None = None):
         """Add separator at the given location."""

--- a/tabulous/_qt/_mainwindow/_base.py
+++ b/tabulous/_qt/_mainwindow/_base.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 import qtpy
 from qtpy import QtWidgets as QtW, QtGui, QtCore
 from qtpy.QtCore import QEvent, Signal
@@ -57,9 +57,12 @@ class _QtMainWidgetBase(QtW.QWidget):
         self._event_filter.styleChanged.connect(self.updateWidgetStyle)
         self._console_widget: QtConsole | None = None
         self._keymap_widget = None
-        self._namespace = Namespace()
+
+        # Queued namespaces for console
+        self._queued_ns: dict[str, Any] = {}
 
         # update with user namespace
+        self._namespace = Namespace()
         self._namespace.update_safely(load_cell_namespace())
 
         # install command palette

--- a/tabulous/_qt/_mainwindow/_mainwidgets.py
+++ b/tabulous/_qt/_mainwindow/_mainwidgets.py
@@ -73,6 +73,10 @@ class QMainWidget(QtW.QSplitter, _QtMainWidgetBase):
             self.addWidget(qtconsole)
             self._console_widget = qtconsole
 
+            if qtconsole.shell is not None:
+                qtconsole.update_console(self._queued_ns)
+                self._queued_ns.clear()
+
         self._console_widget.setVisible(visible)
 
         if visible:
@@ -151,7 +155,7 @@ class QMainWindow(QtW.QMainWindow, _QtMainWidgetBase):
     def setConsoleVisible(self, visible: bool) -> None:
         """Set visibility of embeded console widget."""
         if visible and self._console_widget is None:
-            from .._console import QtConsole
+            from tabulous._qt._console import QtConsole
 
             qtconsole = QtConsole()
             qtconsole.connect_parent(self._table_viewer)
@@ -159,6 +163,10 @@ class QMainWindow(QtW.QMainWindow, _QtMainWidgetBase):
             qtconsole.setDockParent(dock)
             dock.setSourceObject(qtconsole)
             self._console_widget = qtconsole
+
+            if qtconsole.shell is not None:
+                qtconsole.update_console(self._queued_ns)
+                self._queued_ns.clear()
 
         else:
             dock = self._console_widget.dockParent()

--- a/tabulous/_qt/_mainwindow/_namespace.py
+++ b/tabulous/_qt/_mainwindow/_namespace.py
@@ -53,6 +53,9 @@ class Namespace(MutableMapping[str, Any]):
 
     def add(self, obj: _T) -> _T:
         """A decorator to add an callable object to the namespace."""
-        name = obj.__name__
-        self[name] = obj
+        if callable(obj) or isinstance(obj, type):
+            name = obj.__name__
+            self[name] = obj
+        else:
+            raise TypeError(f"Expected to be used as a decorator, got {type(obj)}")
         return obj

--- a/tabulous/_utils.py
+++ b/tabulous/_utils.py
@@ -95,11 +95,15 @@ def load_cell_namespace() -> MappingProxyType:
 
 @warn_on_exc(default=None)
 def get_post_initializers():
-    from tabulous.post_init import TableInitializer, ViewerInitializer
-
     code = _compile_file(POST_INIT_PATH)
     ns: dict[str, Any] = {}
     exec(code, {}, ns)
+
+    if len(ns) == 0:
+        # if file is empty, don't do anything
+        return None
+
+    from tabulous.post_init import TableInitializer, ViewerInitializer
 
     table_initializer = TableInitializer()
     viewer_initializer = ViewerInitializer()

--- a/tabulous/_utils.py
+++ b/tabulous/_utils.py
@@ -279,11 +279,11 @@ _POST_INIT_TEXT = """
 
 # 2. Add custom keybindings to viewers and tables.
 
-# @viewer.keymap.bind("Ctrl+K, Ctrl+1")
+# @viewer.keymap.register("Ctrl+K, Ctrl+1")
 # def _my_keybinding(viewer):
 #     print(viewer)
 
-# @table.keymap.bind("Ctrl+K, Ctrl+2")
+# @table.keymap.register("Ctrl+K, Ctrl+2")
 # def _my_keybinding(table):
 #     print(table)
 

--- a/tabulous/_utils.py
+++ b/tabulous/_utils.py
@@ -95,7 +95,6 @@ def load_cell_namespace() -> MappingProxyType:
     return MappingProxyType(ns)
 
 
-@warn_on_exc(default=None)
 def get_post_initializers():
     code = _compile_file(POST_INIT_PATH, default_text=_POST_INIT_TEXT)
     ns: dict[str, Any] = {}
@@ -283,7 +282,7 @@ _POST_INIT_TEXT = """
 # def _my_keybinding(viewer):
 #     print(viewer)
 
-# @table.keymap.register("Ctrl+K, Ctrl+2")
+# @table.keymap.register("Ctrl+Shift+K, Ctrl+1")
 # def _my_keybinding(table):
 #     print(table)
 

--- a/tabulous/_utils.py
+++ b/tabulous/_utils.py
@@ -273,7 +273,7 @@ _POST_INIT_TEXT = """
 
 # 1. Add custom actions to the right-click context menu of table columns.
 
-# @table.columns.register_action("User defined > Print column name")
+# @table.columns.register("User defined > Print column name")
 # def _print_column_name(table, index):
 #     print(table.columns[index])
 

--- a/tabulous/commands/__init__.py
+++ b/tabulous/commands/__init__.py
@@ -36,6 +36,7 @@ def iter_commands() -> Iterator[tuple[str, FunctionType]]:
 
 
 def register_command(
+    func: Callable = None,
     title: str = "User defined",
     desc: str = None,
 ) -> Callable[[Callable[[TableViewerBase], Any]], Callable[[TableViewerBase], Any]]:
@@ -60,7 +61,7 @@ def register_command(
         palette.update()
         return f
 
-    return wrapper
+    return wrapper if func is None else wrapper(func)
 
 
 DEFAULT_KEYBINDING_SETTING: list[tuple[FunctionType, str]] = [

--- a/tabulous/post_init.py
+++ b/tabulous/post_init.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Callable, Generic, TypeVar, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tabulous.widgets import TableViewerBase, TableBase
+
+_T = TypeVar("_T")
+
+
+class MockObject(Generic[_T]):
+    def __init__(self, name: str = ""):
+        self._name = name
+        self._registered: list[_T] = []
+        self._instances = {}
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        if (out := self._instances.get(instance, None)) is None:
+            out = self._instances[instance] = self.__class__(self._name)
+        return out
+
+    def __set_name__(self, owner, name):
+        self._name = name
+
+    def iter_registered(self):
+        return iter(self._registered)
+
+
+class ContextRegisterable(MockObject[Tuple[str, Callable]]):
+    def register_action(self, loc: str, func: Callable | None = None):
+        def wrapper(f: Callable):
+            self._registered.append((loc, f))
+            return f
+
+        return wrapper(func) if func is not None else wrapper
+
+
+class KeyMapMock(MockObject[Tuple[str, Callable]]):
+    def bind(self, *args):
+        self._registered.append(args)
+
+
+class Initializer:
+    _fields = ()
+
+    def __hash__(self):
+        return id(self)
+
+    def join(self, other: Initializer):
+        """Join initializers together."""
+        for name in self._fields:
+            self_field: MockObject = getattr(self, name)
+            other_field: MockObject = getattr(other, name)
+            self_field._registered.extend(other_field._registered)
+        return self
+
+
+class ViewerInitializer(Initializer):
+    tables = ContextRegisterable("tables")
+    keymap = KeyMapMock("keymap")
+
+    _fields = ("tables", "keymap")
+
+    def initializer_viewer(self, viewer: TableViewerBase):
+        for args in self.tables.iter_registered():
+            viewer.tables.register_action(*args)
+        for args in self.keymap.iter_registered():
+            viewer.keymap.bind(*args)
+
+
+class TableInitializer(Initializer):
+    cell = ContextRegisterable("cell")
+    index = ContextRegisterable("index")
+    columns = ContextRegisterable("columns")
+
+    _fields = ("cell", "index", "columns")
+
+    def initializer_table(self, table: TableBase):
+        for args in self.cell.iter_registered():
+            table.cell.register_action(*args)
+        for args in self.index.iter_registered():
+            table.index.register_action(*args)
+        for args in self.columns.iter_registered():
+            table.columns.register_action(*args)
+
+
+def get_initializer() -> tuple[ViewerInitializer, TableInitializer]:
+    return ViewerInitializer(), TableInitializer()

--- a/tabulous/post_init.py
+++ b/tabulous/post_init.py
@@ -96,12 +96,12 @@ class KeyMapMock(_Registerable):
 
     # fmt: off
     @overload
-    def bind(self, key: str, func: Literal[None] = None) -> Callable[[Callable[[TableViewerBase, Any], None]], Callable[[TableViewerBase, Any], None]]: ...  # noqa: E501
+    def register(self, key: str, func: Literal[None] = None) -> Callable[[Callable[[TableViewerBase, Any], None]], Callable[[TableViewerBase, Any], None]]: ...  # noqa: E501
     @overload
-    def bind(self, key: str, func: Callable[[TableViewerBase, Any], None]) -> Callable[[TableViewerBase, Any], None]: ...  # noqa: E501
+    def register(self, key: str, func: Callable[[TableViewerBase, Any], None]) -> Callable[[TableViewerBase, Any], None]: ...  # noqa: E501
     # fmt: on
 
-    def bind(self, key, func=None):
+    def register(self, key, func=None):
         return self._register(key, func)
 
 
@@ -151,13 +151,16 @@ class ViewerInitializer(Initializer):
 
     def initialize_viewer(self, viewer: TableViewerBase):
         for args in self.tables._registered:
-            viewer.tables.register(args)
+            viewer.tables.register(*args)
         for args in self.keymap._registered:
-            viewer.keymap.register(args)
+            # NOTE: The QtKeyMap object is currently a class variable. When the second
+            # viewer is launched, old keybindings are still registered. To avoid this,
+            # we just allow overwriting the keymap.
+            viewer.keymap.register(*args, overwrite=True)
         viewer.cell_namespace.update_safely(self.cell_namespace._dict)
         viewer.console.update(self.console._dict)
         for args in self.command_palette._registered:
-            viewer.command_palette.register(args)
+            viewer.command_palette.register(*args)
 
 
 class TableInitializer(Initializer):
@@ -170,13 +173,13 @@ class TableInitializer(Initializer):
 
     def initialize_table(self, table: TableBase):
         for args in self.cell._registered:
-            table.cell.register(args)
+            table.cell.register(*args)
         for args in self.index._registered:
-            table.index.register(args)
+            table.index.register(*args)
         for args in self.columns._registered:
-            table.columns.register(args)
+            table.columns.register(*args)
         for args in self.keymap._registered:
-            table.keymap.register(args)
+            table.keymap.register(*args, overwrite=True)
 
 
 _VIEWER_INITIALIZER = ViewerInitializer()

--- a/tabulous/post_init.py
+++ b/tabulous/post_init.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import partial
 from typing import (
     Any,
     Callable,
@@ -79,16 +78,16 @@ class _Updatable(_Joinable):
 
 
 class ContextRegisterable(_Registerable, Generic[_T]):
-    """A mock for the `register_action` method."""
+    """A mock for the `register` method."""
 
     # fmt: off
     @overload
-    def register_action(self, loc: str, func: Literal[None] = None) -> Callable[[Callable[[_T, Any], None]], Callable[[_T, Any], None]]: ...  # noqa: E501
+    def register(self, loc: str, func: Literal[None] = None) -> Callable[[Callable[[_T, Any], None]], Callable[[_T, Any], None]]: ...  # noqa: E501
     @overload
-    def register_action(self, loc: str, func: Callable[[_T, Any], None]) -> Callable[[_T, Any], None]: ...  # noqa: E501
+    def register(self, loc: str, func: Callable[[_T, Any], None]) -> Callable[[_T, Any], None]: ...  # noqa: E501
     # fmt: on
 
-    def register_action(self, loc, func=None):
+    def register(self, loc, func=None):
         return self._register(loc, func)
 
 
@@ -140,11 +139,6 @@ class Initializer:
             self_field._join(other_field)
         return self
 
-    def wrap_args(self, args: tuple[Any, Callable], parent) -> tuple[Any, Callable]:
-        arg, f = args
-        f = partial(f, parent)
-        return arg, f
-
 
 class ViewerInitializer(Initializer):
     tables: ContextRegisterable[TableViewerBase] = ContextRegisterable()
@@ -157,9 +151,9 @@ class ViewerInitializer(Initializer):
 
     def initialize_viewer(self, viewer: TableViewerBase):
         for args in self.tables._registered:
-            viewer.tables.register_action(*self.wrap_args(args, parent=viewer))
+            viewer.tables.register(args)
         for args in self.keymap._registered:
-            viewer.keymap.bind(*self.wrap_args(args, parent=viewer))
+            viewer.keymap.register(args)
         viewer.cell_namespace.update_safely(self.cell_namespace._dict)
         viewer.console.update(self.console._dict)
         for args in self.command_palette._registered:
@@ -176,13 +170,13 @@ class TableInitializer(Initializer):
 
     def initialize_table(self, table: TableBase):
         for args in self.cell._registered:
-            table.cell.register_action(*self.wrap_args(args, parent=table))
+            table.cell.register(args)
         for args in self.index._registered:
-            table.index.register_action(*self.wrap_args(args, parent=table))
+            table.index.register(args)
         for args in self.columns._registered:
-            table.columns.register_action(*self.wrap_args(args, parent=table))
+            table.columns.register(args)
         for args in self.keymap._registered:
-            table.keymap.bind(*self.wrap_args(args, parent=table))
+            table.keymap.register(args)
 
 
 _VIEWER_INITIALIZER = ViewerInitializer()

--- a/tabulous/post_init.py
+++ b/tabulous/post_init.py
@@ -134,6 +134,9 @@ class Initializer:
         return arg, f
 
 
+# TODO: command palette
+
+
 class ViewerInitializer(Initializer):
     tables: ContextRegisterable[TableViewerBase] = ContextRegisterable()
     keymap: ContextRegisterable[TableViewerBase] = KeyMapMock()
@@ -155,8 +158,9 @@ class TableInitializer(Initializer):
     cell: ContextRegisterable[TableBase] = ContextRegisterable()
     index: ContextRegisterable[TableBase] = ContextRegisterable()
     columns: ContextRegisterable[TableBase] = ContextRegisterable()
+    keymap: ContextRegisterable[TableBase] = KeyMapMock()
 
-    _fields = ("cell", "index", "columns")
+    _fields = ("cell", "index", "columns", "keymap")
 
     def initialize_table(self, table: TableBase):
         for args in self.cell._registered:
@@ -165,6 +169,8 @@ class TableInitializer(Initializer):
             table.index.register_action(*self.wrap_args(args, parent=table))
         for args in self.columns._registered:
             table.columns.register_action(*self.wrap_args(args, parent=table))
+        for args in self.keymap._registered:
+            table.keymap.bind(*self.wrap_args(args, parent=table))
 
 
 _VIEWER_INITIALIZER = ViewerInitializer()

--- a/tabulous/post_init.py
+++ b/tabulous/post_init.py
@@ -79,6 +79,8 @@ class _Updatable(_Joinable):
 
 
 class ContextRegisterable(_Registerable, Generic[_T]):
+    """A mock for the `register_action` method."""
+
     # fmt: off
     @overload
     def register_action(self, loc: str, func: Literal[None] = None) -> Callable[[Callable[[_T, Any], None]], Callable[[_T, Any], None]]: ...  # noqa: E501
@@ -91,6 +93,8 @@ class ContextRegisterable(_Registerable, Generic[_T]):
 
 
 class KeyMapMock(_Registerable):
+    """A mock for the `keymap` attribute of a table viewer instance."""
+
     # fmt: off
     @overload
     def bind(self, key: str, func: Literal[None] = None) -> Callable[[Callable[[TableViewerBase, Any], None]], Callable[[TableViewerBase, Any], None]]: ...  # noqa: E501
@@ -103,11 +107,11 @@ class KeyMapMock(_Registerable):
 
 
 class CellNamespaceMock(_Updatable):
-    pass
+    """A mock for the `cell_namespace` attribute of a table viewer instance."""
 
 
 class ConsoleMock(_Updatable):
-    pass
+    """A mock for the `console` attribute of a table viewer instance."""
 
 
 class Initializer:
@@ -163,5 +167,9 @@ class TableInitializer(Initializer):
             table.columns.register_action(*self.wrap_args(args, parent=table))
 
 
-def get_initializer() -> tuple[ViewerInitializer, TableInitializer]:
-    return ViewerInitializer(), TableInitializer()
+_VIEWER_INITIALIZER = ViewerInitializer()
+_TABLE_INITIALIZER = TableInitializer()
+
+
+def get_initializers() -> tuple[ViewerInitializer, TableInitializer]:
+    return _VIEWER_INITIALIZER, _TABLE_INITIALIZER

--- a/tabulous/widgets/_component/__init__.py
+++ b/tabulous/widgets/_component/__init__.py
@@ -11,6 +11,7 @@ from ._column_setting import (
     ColumnDtypeInterface,
 )
 from ._proxy import ProxyInterface
+from ._viewer import Toolbar, Console, CommandPalette
 from ._table_subset import TableSeries, TableSubset, TableLocIndexer, TableILocIndexer
 
 __all__ = [
@@ -34,4 +35,7 @@ __all__ = [
     "TableSubset",
     "TableLocIndexer",
     "TableILocIndexer",
+    "Toolbar",
+    "Console",
+    "CommandPalette",
 ]

--- a/tabulous/widgets/_component/__init__.py
+++ b/tabulous/widgets/_component/__init__.py
@@ -13,6 +13,7 @@ from ._column_setting import (
 from ._proxy import ProxyInterface
 from ._viewer import Toolbar, Console, CommandPalette
 from ._table_subset import TableSeries, TableSubset, TableLocIndexer, TableILocIndexer
+from ._keymap import KeyMap
 
 __all__ = [
     "Component",
@@ -38,4 +39,5 @@ __all__ = [
     "Toolbar",
     "Console",
     "CommandPalette",
+    "KeyMap",
 ]

--- a/tabulous/widgets/_component/_cell.py
+++ b/tabulous/widgets/_component/_cell.py
@@ -5,9 +5,7 @@ from typing import (
     Mapping,
     SupportsIndex,
     Tuple,
-    TypeVar,
     Any,
-    Callable,
     Iterator,
 )
 import warnings
@@ -25,8 +23,7 @@ from tabulous.widgets._registry import SupportActionRegistration
 
 if TYPE_CHECKING:
     import pandas as pd
-
-_F = TypeVar("_F", bound=Callable)
+    from tabulous.widgets import TableBase  # noqa: F401
 
 
 class _Sequence2D(TableComponent):
@@ -115,7 +112,7 @@ class CellDisplayedTextInterface(_Sequence2D):
         return model.data(idx, role=Qt.ItemDataRole.DisplayRole)
 
 
-class CellInterface(TableComponent, SupportActionRegistration):
+class CellInterface(TableComponent, SupportActionRegistration["TableBase", int]):
     """
     Interface with table cells.
 
@@ -132,10 +129,10 @@ class CellInterface(TableComponent, SupportActionRegistration):
     >>> table.cell.label[i, j] = value  # set the (i, j) cell label text
     >>> del table.cell.label[i, j]  # delete the (i, j) cell label text
 
-    Use ``register_action`` to register a contextmenu function.
+    Use ``register`` to register a contextmenu function.
 
-    >>> @table.cell.register_action("My Action")
-    >>> def my_action(index):
+    >>> @table.cell.register("My Action")
+    >>> def my_action(table, index):
     ...     # do something
     """
 

--- a/tabulous/widgets/_component/_cell.py
+++ b/tabulous/widgets/_component/_cell.py
@@ -6,7 +6,6 @@ from typing import (
     SupportsIndex,
     Tuple,
     TypeVar,
-    overload,
     Any,
     Callable,
     Iterator,
@@ -22,6 +21,7 @@ from tabulous.types import EvalInfo
 from tabulous.color import ColorTuple
 from tabulous._psygnal import InCellRangedSlot
 from ._base import TableComponent
+from tabulous.widgets._registry import SupportActionRegistration
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -115,7 +115,7 @@ class CellDisplayedTextInterface(_Sequence2D):
         return model.data(idx, role=Qt.ItemDataRole.DisplayRole)
 
 
-class CellInterface(TableComponent):
+class CellInterface(TableComponent, SupportActionRegistration):
     """
     Interface with table cells.
 
@@ -222,23 +222,8 @@ class CellInterface(TableComponent):
             col = slice(col, col + 1)
         return row, col
 
-    # fmt: off
-    @overload
-    def register_action(self, val: str) -> Callable[[_F], _F]: ...
-    @overload
-    def register_action(self, val: _F) -> _F: ...
-    # fmt: on
-
-    def register_action(self, val: str | Callable[[tuple[int, int]], Any]):
-        """Register an contextmenu action to the tablelist."""
-        table = self.parent.native
-        if isinstance(val, str):
-            return table.registerAction(val)
-        elif callable(val):
-            location = val.__name__.replace("_", " ")
-            return table.registerAction(location)(val)
-        else:
-            raise TypeError("input must be a string or callable.")
+    def _get_qregistry(self):
+        return self.parent.native
 
     label = CellLabelInterface()
     ref = CellReferenceInterface()

--- a/tabulous/widgets/_component/_header.py
+++ b/tabulous/widgets/_component/_header.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     Sequence,
-    TypeVar,
     overload,
     Any,
-    Callable,
     Iterator,
 )
 
@@ -17,9 +15,8 @@ from tabulous.widgets._registry import SupportActionRegistration
 
 if TYPE_CHECKING:
     import pandas as pd
+    from tabulous.widgets import TableBase  # noqa: F401
     from tabulous._qt._table._base._header_view import QDataFrameHeaderView
-
-_F = TypeVar("_F", bound=Callable)
 
 
 class HeaderSectionSpan(Component["_HeaderInterface"]):
@@ -54,7 +51,7 @@ class HeaderSectionSpan(Component["_HeaderInterface"]):
         return None
 
 
-class _HeaderInterface(TableComponent, SupportActionRegistration):
+class _HeaderInterface(TableComponent, SupportActionRegistration["TableBase", int]):
     """
     Interface to the table {index/columns} header.
 
@@ -75,10 +72,10 @@ class _HeaderInterface(TableComponent, SupportActionRegistration):
     >>> table.{index/columns}.insert(at=0, count=2)
     >>> table.{index/columns}.remove(at=0, count=2)
 
-    Use ``register_action`` to register a contextmenu function.
+    Use ``register`` to register a contextmenu function.
 
-    >>> @table.{index/columns}.register_action("My Action")
-    >>> def my_action(index):
+    >>> @table.{index/columns}.register("My Action")
+    >>> def my_action(table, index):
     ...     # do something
 
     Many other pandas.Index methods are also available.

--- a/tabulous/widgets/_component/_header.py
+++ b/tabulous/widgets/_component/_header.py
@@ -13,6 +13,7 @@ from typing import (
 import numpy as np
 from tabulous.exceptions import TableImmutableError
 from ._base import Component, TableComponent
+from tabulous.widgets._registry import SupportActionRegistration
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -53,7 +54,7 @@ class HeaderSectionSpan(Component["_HeaderInterface"]):
         return None
 
 
-class _HeaderInterface(TableComponent):
+class _HeaderInterface(TableComponent, SupportActionRegistration):
     """
     Interface to the table {index/columns} header.
 
@@ -167,23 +168,8 @@ class _HeaderInterface(TableComponent):
             i += 1
         return name
 
-    # fmt: off
-    @overload
-    def register_action(self, val: str) -> Callable[[_F], _F]: ...
-    @overload
-    def register_action(self, val: _F) -> _F: ...
-    # fmt: on
-
-    def register_action(self, val: str | Callable[[int], Any]):
-        """Register an contextmenu action to the header."""
-        header = self._get_header()
-        if isinstance(val, str):
-            return header.registerAction(val)
-        elif callable(val):
-            location = val.__name__.replace("_", " ")
-            return header.registerAction(location)(val)
-        else:
-            raise ValueError("input must be a string or callable.")
+    def _get_qregistry(self):
+        return self._get_header()
 
     @property
     def selected(self) -> list[slice]:

--- a/tabulous/widgets/_component/_keymap.py
+++ b/tabulous/widgets/_component/_keymap.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Any
+from ._base import Component
+
+if TYPE_CHECKING:
+    from tabulous.widgets._keymap_abc import SupportKeyMap
+
+
+class KeyMap(Component["SupportKeyMap"]):
+    def register(
+        self,
+        key: str,
+        func: Callable[[SupportKeyMap], Any] | None = None,
+        overwrite: bool = False,
+    ):
+        def wrapper(f):
+            def _inner(*_):
+                return f(self.parent)
+
+            return self.parent._qwidget._keymap.bind(key, _inner, overwrite=overwrite)
+
+        return wrapper if func is None else wrapper(func)
+
+    def unregister(self, key: str) -> None:
+        self.parent._qwidget._keymap.unbind(key)
+
+    def press_key(self, key: str) -> None:
+        self.parent._qwidget._keymap.press_key(key)
+        return None
+
+
+def bind(self: KeyMap, *args, **kwargs):
+    import warnings
+
+    warnings.warn(
+        "Keycombo registration using `keymap.bind` is deprecated. Use "
+        "`keymap.register` instead.",
+        DeprecationWarning,
+    )
+    return self.parent._qwidget._keymap.bind(*args, **kwargs)
+
+
+KeyMap.bind = bind  # backward compatibility

--- a/tabulous/widgets/_component/_viewer.py
+++ b/tabulous/widgets/_component/_viewer.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+from typing import Callable, Any, TYPE_CHECKING
+from ._base import ViewerComponent
+
+if TYPE_CHECKING:
+    from tabulous.widgets import TableViewerBase
+
+
+class Toolbar(ViewerComponent):
+    """The toolbar proxy."""
+
+    @property
+    def visible(self) -> bool:
+        """Visibility of the toolbar."""
+        return self.parent._qwidget.toolBarVisible()
+
+    @visible.setter
+    def visible(self, val) -> None:
+        return self.parent._qwidget.setToolBarVisible(val)
+
+    @property
+    def current_index(self) -> int:
+        return self.parent._qwidget._toolbar.currentIndex()
+
+    @current_index.setter
+    def current_index(self, val: int) -> None:
+        return self.parent._qwidget._toolbar.setCurrentIndex(val)
+
+    def register_action(self, f: Callable):
+        raise NotImplementedError()
+
+
+class Console(ViewerComponent):
+    """The QtConsole proxy."""
+
+    @property
+    def visible(self) -> bool:
+        """Visibility of the console."""
+        return self.parent._qwidget.consoleVisible()
+
+    @visible.setter
+    def visible(self, val) -> None:
+        return self.parent._qwidget.setConsoleVisible(val)
+
+    @property
+    def is_active(self) -> bool:
+        return self.parent._qwidget._console_widget is not None
+
+    def _get_console_widget(self):
+        console = self.parent._qwidget._console_widget
+        if console is None:
+            raise RuntimeError("Console is not active.")
+        return console
+
+    @property
+    def buffer(self) -> str:
+        """Return the current text buffer of the console."""
+        return self._get_console_widget().input_buffer
+
+    @buffer.setter
+    def buffer(self, val) -> None:
+        return self._get_console_widget().setBuffer(val)
+
+    def execute(self):
+        """Execute current buffer."""
+        return self._get_console_widget().execute()
+
+    def update(self, ns: dict[str, Any]):
+        """Update IPython namespace."""
+        console = self.parent._qwidget._console_widget
+        if console is None:
+            self.parent._qwidget._queued_ns.update(ns)
+        else:
+            self._get_console_widget().update_console(ns)
+        return None
+
+
+class CommandPalette(ViewerComponent):
+    def register(
+        self,
+        command: Callable[[TableViewerBase], Any] | None = None,
+        title: str = "User defined",
+        desc: str | None = None,
+        key: str | None = None,
+    ):
+        """Register a command."""
+        from tabulous.commands import register_command
+
+        if key is not None:
+            self.parent.keymap.bind(key, command)
+        return register_command(command, title=title, desc=desc)
+
+    @property
+    def visible(self) -> bool:
+        """Visibility of the command palette."""
+        qviewer = self.parent._qwidget
+        return qviewer._command_palette.get_widget(qviewer).isVisible()
+
+    @visible.setter
+    def visible(self, val) -> None:
+        qviewer = self.parent._qwidget
+        return qviewer._command_palette.get_widget(qviewer).setVisible(val)

--- a/tabulous/widgets/_component/_viewer.py
+++ b/tabulous/widgets/_component/_viewer.py
@@ -26,7 +26,7 @@ class Toolbar(ViewerComponent):
     def current_index(self, val: int) -> None:
         return self.parent._qwidget._toolbar.setCurrentIndex(val)
 
-    def register_action(self, f: Callable):
+    def register(self, loc: str, f: Callable):
         raise NotImplementedError()
 
 
@@ -87,7 +87,7 @@ class CommandPalette(ViewerComponent):
         from tabulous.commands import register_command
 
         if key is not None:
-            self.parent.keymap.bind(key, command)
+            self.parent.keymap.register(key, command)
         return register_command(command, title=title, desc=desc)
 
     @property

--- a/tabulous/widgets/_component/_viewer.py
+++ b/tabulous/widgets/_component/_viewer.py
@@ -78,13 +78,25 @@ class Console(ViewerComponent):
 class CommandPalette(ViewerComponent):
     def register(
         self,
+        name: str,
         command: Callable[[TableViewerBase], Any] | None = None,
-        title: str = "User defined",
-        desc: str | None = None,
+        *,
         key: str | None = None,
     ):
         """Register a command."""
         from tabulous.commands import register_command
+
+        if callable(name):
+            name = None
+            command = name
+
+        elif ":" in name:
+            title, desc = name.split(":", maxsplit=1)
+            title = title.strip()
+            desc = desc.strip()
+        else:
+            title = "User defined"
+            desc = name
 
         if key is not None:
             self.parent.keymap.register(key, command)

--- a/tabulous/widgets/_keymap_abc.py
+++ b/tabulous/widgets/_keymap_abc.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from abc import ABC
+from typing import TYPE_CHECKING
+from ._component import KeyMap
+
+if TYPE_CHECKING:
+    from tabulous._qt._mainwindow import _QtMainWidgetBase
+    from tabulous._qt._table import QBaseTable
+
+
+class SupportKeyMap(ABC):
+    _qwidget: QBaseTable | _QtMainWidgetBase
+
+    keymap = KeyMap()

--- a/tabulous/widgets/_mainwindow.py
+++ b/tabulous/widgets/_mainwindow.py
@@ -170,6 +170,7 @@ class TableViewerBase(_AbstractViewer):
         show: bool = True,
     ):
         from tabulous._qt import get_app
+        from tabulous._utils import get_post_initializers
 
         app = get_app()  # noqa: F841
         self._qwidget = self._qwidget_class(tab_position=tab_position)
@@ -178,6 +179,11 @@ class TableViewerBase(_AbstractViewer):
         self._link_events()
 
         self.events = TableViewerSignal()
+        self._table_initializer = None
+        _init = get_post_initializers()
+        if _init is not None:
+            viewer_initializer, self._table_initializer = _init
+            viewer_initializer.initializer_viewer(self)
 
         if show:
             self.show(run=False)
@@ -384,6 +390,8 @@ class TableViewerBase(_AbstractViewer):
         self.current_index = -1  # activate the last table
 
         self._qwidget.setCellFocus()
+        if self._table_initializer is not None:
+            self._table_initializer.initializer_table(input)
         return input
 
     def open(self, path: PathLike, *, type: TableType | str = TableType.table) -> None:

--- a/tabulous/widgets/_mainwindow.py
+++ b/tabulous/widgets/_mainwindow.py
@@ -12,7 +12,7 @@ from psygnal import Signal, SignalGroup
 from ._table import Table, SpreadSheet, GroupBy, TableDisplay
 from ._tablelist import TableList
 from ._sample import open_sample
-from ._component import ViewerComponent
+from ._component import Toolbar, Console, CommandPalette
 from . import _doc
 
 from tabulous import _utils, _io
@@ -43,75 +43,6 @@ class TableViewerSignal(SignalGroup):
     """Signal group for table viewer."""
 
     current_index = Signal(int)
-
-
-class Toolbar(ViewerComponent):
-    """The toolbar proxy."""
-
-    @property
-    def visible(self) -> bool:
-        """Visibility of the toolbar."""
-        return self.parent._qwidget.toolBarVisible()
-
-    @visible.setter
-    def visible(self, val) -> None:
-        return self.parent._qwidget.setToolBarVisible(val)
-
-    @property
-    def current_index(self) -> int:
-        return self.parent._qwidget._toolbar.currentIndex()
-
-    @current_index.setter
-    def current_index(self, val: int) -> None:
-        return self.parent._qwidget._toolbar.setCurrentIndex(val)
-
-    def register_action(self, f: Callable):
-        raise NotImplementedError()
-
-
-class Console(ViewerComponent):
-    """The QtConsole proxy."""
-
-    @property
-    def visible(self) -> bool:
-        """Visibility of the console."""
-        return self.parent._qwidget.consoleVisible()
-
-    @visible.setter
-    def visible(self, val) -> None:
-        return self.parent._qwidget.setConsoleVisible(val)
-
-    @property
-    def is_active(self) -> bool:
-        return self.parent._qwidget._console_widget is not None
-
-    def _get_console_widget(self):
-        console = self.parent._qwidget._console_widget
-        if console is None:
-            raise RuntimeError("Console is not active.")
-        return console
-
-    @property
-    def buffer(self) -> str:
-        """Return the current text buffer of the console."""
-        return self._get_console_widget().input_buffer
-
-    @buffer.setter
-    def buffer(self, val) -> None:
-        return self._get_console_widget().setBuffer(val)
-
-    def execute(self):
-        """Execute current buffer."""
-        return self._get_console_widget().execute()
-
-    def update(self, ns: dict[str, Any]):
-        """Update IPython namespace."""
-        console = self.parent._qwidget._console_widget
-        if console is None:
-            self.parent._qwidget._queued_ns.update(ns)
-        else:
-            self._get_console_widget().update_console(ns)
-        return None
 
 
 class _AbstractViewer(ABC):
@@ -177,6 +108,7 @@ class TableViewerBase(_AbstractViewer):
 
     toolbar = Toolbar()
     console = Console()
+    command_palette = CommandPalette()
 
     def __init__(
         self,

--- a/tabulous/widgets/_mainwindow.py
+++ b/tabulous/widgets/_mainwindow.py
@@ -18,7 +18,7 @@ from . import _doc
 from tabulous import _utils, _io
 from tabulous.types import SelectionType, TabPosition, _TableLike, _SingleSelection
 from tabulous.exceptions import UnreachableError
-from tabulous._keymap import QtKeyMap
+from tabulous.widgets._keymap_abc import SupportKeyMap
 
 if TYPE_CHECKING:
     from tabulous.widgets._table import TableBase
@@ -58,10 +58,6 @@ class _AbstractViewer(ABC):
     def cell_namespace(self) -> Namespace:
         """Return the namespace of the cell editor."""
 
-    @abstractproperty
-    def keymap(self) -> QtKeyMap:
-        """Return the keymap object."""
-
     @property
     def data(self) -> pd.DataFrame | None:
         """The data of the current table if exists."""
@@ -100,7 +96,7 @@ class _AbstractViewer(ABC):
         return self.current_table._qwidget.pasteFromClipBoard()
 
 
-class TableViewerBase(_AbstractViewer):
+class TableViewerBase(_AbstractViewer, SupportKeyMap):
     """The base class of a table viewer widget."""
 
     events: TableViewerSignal
@@ -142,11 +138,6 @@ class TableViewerBase(_AbstractViewer):
     def tables(self) -> TableList:
         """Return the table list object."""
         return self._tablist
-
-    @property
-    def keymap(self) -> QtKeyMap:
-        """Return the keymap object."""
-        return self._qwidget._keymap
 
     @property
     def current_table(self) -> TableBase | None:
@@ -622,7 +613,6 @@ class DummyViewer(_AbstractViewer):
     """
 
     _namespace: Namespace | None = None
-    _keymap: QtKeyMap = QtKeyMap()
 
     def __init__(self, table: TableBase):
         self._table = table
@@ -648,10 +638,6 @@ class DummyViewer(_AbstractViewer):
             # update with user namespace
             cls._namespace.update_safely(load_cell_namespace())
         return cls._namespace
-
-    @property
-    def keymap(self) -> QtKeyMap:
-        return self._keymap
 
 
 def _normalize_widget(widget: Widget | QWidget, name: str) -> tuple[QWidget, str]:

--- a/tabulous/widgets/_registry.py
+++ b/tabulous/widgets/_registry.py
@@ -1,26 +1,67 @@
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING, Callable, overload, TypeVar
+from functools import partial
+from typing import Any, TYPE_CHECKING, Callable, overload, TypeVar, Generic
 
 if TYPE_CHECKING:
     from tabulous._qt._action_registry import QActionRegistry
 
-_F = TypeVar("_F")
+_P = TypeVar("_P")
+_T = TypeVar("_T")
 
 
-class SupportActionRegistration:
+class SupportActionRegistration(Generic[_P, _T]):
     def _get_qregistry(self) -> QActionRegistry:
-        raise NotImplementedError
+        raise NotImplementedError()
+
+    @property
+    def parent(self) -> _P:
+        raise NotImplementedError()
+
+    def register_action(self, *args):
+        """Register an contextmenu action."""
+        import warnings
+
+        warnings.warn(
+            "`register_action` is deprecated. Use `register` instead.",
+            DeprecationWarning,
+        )
+
+        reg = self._get_qregistry()
+        nargs = len(args)
+        if nargs == 0 or nargs > 2:
+            raise TypeError("One or two arguments are allowed.")
+        if nargs == 1:
+            arg = args[0]
+            if callable(arg):
+                loc, func = getattr(arg, "__name__", repr(arg)), arg
+            else:
+                loc, func = arg, None
+        else:
+            loc, func = args
+
+        # check type
+        if not isinstance(loc, str) or (func is not None and not callable(func)):
+            arg = type(loc).__name__
+            if func is not None:
+                arg += f", {type(func).__name__}"
+            raise TypeError(f"No overloaded method matched the input ({arg}).")
+
+        def wrapper(f: Callable[[int], Any]):
+            reg.registerAction(loc, f)
+            return f
+
+        return wrapper if func is None else wrapper(func)
 
     # fmt: off
     @overload
-    def register_action(self, location: str) -> Callable[[_F], _F]: ...
+    def register(self, location: str) -> Callable[[Callable[[_P, _T], Any]], Callable[[_P, _T], Any]]: ...  # noqa: E501
     @overload
-    def register_action(self, location: str, func: _F) -> _F: ...
+    def register(self, location: str, func: Callable[[_P, _T], Any]) -> Callable[[_P, _T], Any]: ...  # noqa: E501
     @overload
-    def register_action(self, func: _F) -> _F: ...
+    def register(self, func: Callable[[_P, _T], Any]) -> Callable[[_P, _T], Any]: ...  # noqa: E501
     # fmt: on
 
-    def register_action(self, *args):
+    def register(self, *args):
         """Register an contextmenu action."""
         reg = self._get_qregistry()
         nargs = len(args)
@@ -42,13 +83,14 @@ class SupportActionRegistration:
                 arg += f", {type(func).__name__}"
             raise TypeError(
                 f"No overloaded method matched the input ({arg}).\n"
-                "1. register_action(location: str)\n"
-                "2. register_action(func: Callable)\n"
-                "3. register_action(location: str, func: Callable)"
+                "1. register(location: str)\n"
+                "2. register(func: Callable)\n"
+                "3. register(location: str, func: Callable)"
             )
 
-        def wrapper(f: Callable[[int], Any]):
-            reg.registerAction(loc, f)
+        def wrapper(f: Callable[[_P, int], Any]):
+            meth = partial(f, self.parent)
+            reg.registerAction(loc, meth)
             return f
 
         return wrapper if func is None else wrapper(func)

--- a/tabulous/widgets/_registry.py
+++ b/tabulous/widgets/_registry.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from typing import Any, TYPE_CHECKING, Callable, overload, TypeVar
+
+if TYPE_CHECKING:
+    from tabulous._qt._action_registry import QActionRegistry
+
+_F = TypeVar("_F")
+
+
+class SupportActionRegistration:
+    def _get_qregistry(self) -> QActionRegistry:
+        raise NotImplementedError
+
+    # fmt: off
+    @overload
+    def register_action(self, location: str) -> Callable[[_F], _F]: ...
+    @overload
+    def register_action(self, location: str, func: _F) -> _F: ...
+    @overload
+    def register_action(self, func: _F) -> _F: ...
+    # fmt: on
+
+    def register_action(self, *args):
+        """Register an contextmenu action."""
+        reg = self._get_qregistry()
+        nargs = len(args)
+        if nargs == 0 or nargs > 2:
+            raise TypeError("One or two arguments are allowed.")
+        if nargs == 1:
+            arg = args[0]
+            if callable(arg):
+                loc, func = getattr(arg, "__name__", repr(arg)), arg
+            else:
+                loc, func = arg, None
+        else:
+            loc, func = args
+
+        # check type
+        if not isinstance(loc, str) or (func is not None and not callable(func)):
+            arg = type(loc).__name__
+            if func is not None:
+                arg += f", {type(func).__name__}"
+            raise TypeError(
+                f"No overloaded method matched the input ({arg}).\n"
+                "1. register_action(location: str)\n"
+                "2. register_action(func: Callable)\n"
+                "3. register_action(location: str, func: Callable)"
+            )
+
+        def wrapper(f: Callable[[int], Any]):
+            reg.registerAction(loc, f)
+            return f
+
+        return wrapper if func is None else wrapper(func)

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -545,7 +545,7 @@ class TableBase(ABC):
         _hheader_register("Color > Set text colormap", _wrap(cmds.column.set_text_colormap))  # noqa: E501
         _hheader_register("Color > Reset text colormap", _wrap(cmds.column.reset_text_colormap))  # noqa: E501
         _hheader_register("Color > Set opacity to text colormap", _wrap(cmds.column.set_text_colormap_opacity))  # noqa: E501
-        self._qwidget._qtable_view.horizontalHeader().addSeparator("Color ")
+        self._qwidget._qtable_view.horizontalHeader().addSeparator("Color")
         _hheader_register("Color > Set background colormap", _wrap(cmds.column.set_background_colormap))  # noqa: E501
         _hheader_register("Color > Reset background colormap", _wrap(cmds.column.reset_background_colormap))  # noqa: E501
         _hheader_register("Color > Set opacity to background colormap", _wrap(cmds.column.set_background_colormap_opacity))  # noqa: E501
@@ -563,7 +563,7 @@ class TableBase(ABC):
         _cell_register("Copy as ... > Tab separated text with headers", _wrap(cmds.selection.copy_data_with_header_tab_separated))  # noqa: E501
         _cell_register("Copy as ... > Comma separated text", _wrap(cmds.selection.copy_data_comma_separated))  # noqa: E501
         _cell_register("Copy as ... > Comma separated text with headers", _wrap(cmds.selection.copy_data_with_header_comma_separated))  # noqa: E501
-        self._qwidget.addSeparator("Copy as ... ")
+        self._qwidget.addSeparator("Copy as ...")
         _cell_register("Copy as ... > Markdown", _wrap(cmds.selection.copy_as_markdown))  # noqa: E501
         _cell_register("Copy as ... > reStructuredText grid table", _wrap(cmds.selection.copy_as_rst_grid))  # noqa: E501
         _cell_register("Copy as ... > reStructuredText simple table", _wrap(cmds.selection.copy_as_rst_simple))  # noqa: E501

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -542,49 +542,49 @@ class TableBase(ABC):
 
         # fmt: off
         _hheader_register = self.columns.register_action
-        _hheader_register("Color > Set text colormap")(_wrap(cmds.column.set_text_colormap))  # noqa: E501
-        _hheader_register("Color > Reset text colormap")(_wrap(cmds.column.reset_text_colormap))  # noqa: E501
-        _hheader_register("Color > Set opacity to text colormap")(_wrap(cmds.column.set_text_colormap_opacity))  # noqa: E501
+        _hheader_register("Color > Set text colormap", _wrap(cmds.column.set_text_colormap))  # noqa: E501
+        _hheader_register("Color > Reset text colormap", _wrap(cmds.column.reset_text_colormap))  # noqa: E501
+        _hheader_register("Color > Set opacity to text colormap", _wrap(cmds.column.set_text_colormap_opacity))  # noqa: E501
         self._qwidget._qtable_view.horizontalHeader().addSeparator("Color ")
-        _hheader_register("Color > Set background colormap")(_wrap(cmds.column.set_background_colormap))  # noqa: E501
-        _hheader_register("Color > Reset background colormap")(_wrap(cmds.column.reset_background_colormap))  # noqa: E501
-        _hheader_register("Color > Set opacity to background colormap")(_wrap(cmds.column.set_background_colormap_opacity))  # noqa: E501
+        _hheader_register("Color > Set background colormap", _wrap(cmds.column.set_background_colormap))  # noqa: E501
+        _hheader_register("Color > Reset background colormap", _wrap(cmds.column.reset_background_colormap))  # noqa: E501
+        _hheader_register("Color > Set opacity to background colormap", _wrap(cmds.column.set_background_colormap_opacity))  # noqa: E501
 
-        _hheader_register("Formatter > Set text formatter")(_wrap(cmds.column.set_text_formatter))  # noqa: E501
-        _hheader_register("Formatter > Reset text formatter")(_wrap(cmds.column.reset_text_formatter))  # noqa: E501
+        _hheader_register("Formatter > Set text formatter", _wrap(cmds.column.set_text_formatter))  # noqa: E501
+        _hheader_register("Formatter > Reset text formatter", _wrap(cmds.column.reset_text_formatter))  # noqa: E501
         self._qwidget._qtable_view.horizontalHeader().addSeparator()
-        _hheader_register("Sort")(_wrap(cmds.selection.sort_by_columns))
-        _hheader_register("Filter")(_wrap(cmds.selection.filter_by_columns))
+        _hheader_register("Sort", _wrap(cmds.selection.sort_by_columns))
+        _hheader_register("Filter", _wrap(cmds.selection.filter_by_columns))
         self._qwidget._qtable_view.horizontalHeader().addSeparator()
 
         _cell_register = self.cell.register_action
         _cell_register("Copy")(_wrap(cmds.selection.copy_data_tab_separated))
-        _cell_register("Copy as ... > Tab separated text")(_wrap(cmds.selection.copy_data_tab_separated))  # noqa: E501
-        _cell_register("Copy as ... > Tab separated text with headers")(_wrap(cmds.selection.copy_data_with_header_tab_separated))  # noqa: E501
-        _cell_register("Copy as ... > Comma separated text")(_wrap(cmds.selection.copy_data_comma_separated))  # noqa: E501
-        _cell_register("Copy as ... > Comma separated text with headers")(_wrap(cmds.selection.copy_data_with_header_comma_separated))  # noqa: E501
+        _cell_register("Copy as ... > Tab separated text", _wrap(cmds.selection.copy_data_tab_separated))  # noqa: E501
+        _cell_register("Copy as ... > Tab separated text with headers", _wrap(cmds.selection.copy_data_with_header_tab_separated))  # noqa: E501
+        _cell_register("Copy as ... > Comma separated text", _wrap(cmds.selection.copy_data_comma_separated))  # noqa: E501
+        _cell_register("Copy as ... > Comma separated text with headers", _wrap(cmds.selection.copy_data_with_header_comma_separated))  # noqa: E501
         self._qwidget.addSeparator("Copy as ... ")
-        _cell_register("Copy as ... > Markdown")(_wrap(cmds.selection.copy_as_markdown))  # noqa: E501
-        _cell_register("Copy as ... > reStructuredText grid table")(_wrap(cmds.selection.copy_as_rst_grid))  # noqa: E501
-        _cell_register("Copy as ... > reStructuredText simple table")(_wrap(cmds.selection.copy_as_rst_simple))  # noqa: E501
-        _cell_register("Copy as ... > Latex")(_wrap(cmds.selection.copy_as_latex))
-        _cell_register("Copy as ... > HTML")(_wrap(cmds.selection.copy_as_html))
-        _cell_register("Copy as ... > Literal")(_wrap(cmds.selection.copy_as_literal))
+        _cell_register("Copy as ... > Markdown", _wrap(cmds.selection.copy_as_markdown))  # noqa: E501
+        _cell_register("Copy as ... > reStructuredText grid table", _wrap(cmds.selection.copy_as_rst_grid))  # noqa: E501
+        _cell_register("Copy as ... > reStructuredText simple table", _wrap(cmds.selection.copy_as_rst_simple))  # noqa: E501
+        _cell_register("Copy as ... > Latex", _wrap(cmds.selection.copy_as_latex))
+        _cell_register("Copy as ... > HTML", _wrap(cmds.selection.copy_as_html))
+        _cell_register("Copy as ... > Literal", _wrap(cmds.selection.copy_as_literal))
         self._qwidget.addSeparator("Copy as ... ")
-        _cell_register("Copy as ... > New table")(_wrap(cmds.selection.copy_as_new_table))  # noqa: E501
-        _cell_register("Copy as ... > New spreadsheet")(_wrap(cmds.selection.copy_as_new_spreadsheet))  # noqa: E501
-        _cell_register("Paste")(_wrap(cmds.selection.paste_data_tab_separated))
-        _cell_register("Paste from ... > Tab separated text")(_wrap(cmds.selection.paste_data_tab_separated))  # noqa: E501
-        _cell_register("Paste from ... > Comma separated text")(_wrap(cmds.selection.paste_data_comma_separated))  # noqa: E501
-        _cell_register("Paste from ... > numpy-style text")(_wrap(cmds.selection.paste_data_from_numpy_string))  # noqa: E501
-        _cell_register("Paste from ... > Markdown text")(_wrap(cmds.selection.paste_data_from_markdown))  # noqa: E501
+        _cell_register("Copy as ... > New table", _wrap(cmds.selection.copy_as_new_table))  # noqa: E501
+        _cell_register("Copy as ... > New spreadsheet", _wrap(cmds.selection.copy_as_new_spreadsheet))  # noqa: E501
+        _cell_register("Paste", _wrap(cmds.selection.paste_data_tab_separated))
+        _cell_register("Paste from ... > Tab separated text", _wrap(cmds.selection.paste_data_tab_separated))  # noqa: E501
+        _cell_register("Paste from ... > Comma separated text", _wrap(cmds.selection.paste_data_comma_separated))  # noqa: E501
+        _cell_register("Paste from ... > numpy-style text", _wrap(cmds.selection.paste_data_from_numpy_string))  # noqa: E501
+        _cell_register("Paste from ... > Markdown text", _wrap(cmds.selection.paste_data_from_markdown))  # noqa: E501
         self._qwidget.addSeparator()
-        _cell_register("Sort in-place")(_wrap(cmds.selection.sort_inplace))
+        _cell_register("Sort in-place", _wrap(cmds.selection.sort_inplace))
         self._qwidget.addSeparator()
-        _cell_register("Code ... > Data-changed signal")(_wrap(cmds.selection.write_data_signal_in_console))  # noqa: E501
-        _cell_register("Code ... > Get slice")(_wrap(cmds.selection.write_slice_in_console))  # noqa: E501
-        _cell_register("Add highlight")(_wrap(cmds.selection.add_highlight))
-        _cell_register("Delete highlight")(_wrap(cmds.selection.delete_selected_highlight))  # noqa: E501
+        _cell_register("Code ... > Data-changed signal", _wrap(cmds.selection.write_data_signal_in_console))  # noqa: E501
+        _cell_register("Code ... > Get slice", _wrap(cmds.selection.write_slice_in_console))  # noqa: E501
+        _cell_register("Add highlight", _wrap(cmds.selection.add_highlight))
+        _cell_register("Delete highlight", _wrap(cmds.selection.delete_selected_highlight))  # noqa: E501
         self._qwidget.addSeparator()
         # fmt: on
 
@@ -712,40 +712,40 @@ class SpreadSheet(_DataFrameTableLayer):
         _wrap = self._wrap_command
         # fmt: off
         _vheader_register = self.index.register_action
-        _vheader_register("Insert row above")(_wrap(cmds.selection.insert_row_above))
-        _vheader_register("Insert row below")(_wrap(cmds.selection.insert_row_below))
-        _vheader_register("Remove selected rows")(_wrap(cmds.selection.remove_selected_rows))  # noqa: E501
+        _vheader_register("Insert row above", _wrap(cmds.selection.insert_row_above))
+        _vheader_register("Insert row below", _wrap(cmds.selection.insert_row_below))
+        _vheader_register("Remove selected rows", _wrap(cmds.selection.remove_selected_rows))  # noqa: E501
         self._qwidget._qtable_view.verticalHeader().addSeparator()
 
         _hheader_register = self.columns.register_action
-        _hheader_register("Insert column left")(_wrap(cmds.selection.insert_column_left))  # noqa: E501
-        _hheader_register("Insert column right")(_wrap(cmds.selection.insert_column_right))  # noqa: E501
-        _hheader_register("Remove selected columns")(_wrap(cmds.selection.remove_selected_columns))  # noqa: E501
+        _hheader_register("Insert column left", _wrap(cmds.selection.insert_column_left))  # noqa: E501
+        _hheader_register("Insert column right", _wrap(cmds.selection.insert_column_right))  # noqa: E501
+        _hheader_register("Remove selected columns", _wrap(cmds.selection.remove_selected_columns))  # noqa: E501
         self._qwidget._qtable_view.horizontalHeader().addSeparator()
-        _hheader_register("Column dtype")(_wrap(cmds.selection.set_column_dtype))
+        _hheader_register("Column dtype", _wrap(cmds.selection.set_column_dtype))
         self._qwidget._qtable_view.horizontalHeader().addSeparator()
 
         _cell_register = self._qwidget.registerAction
-        _cell_register("Insert/Remove > Insert a row above")(_wrap(cmds.selection.insert_row_above))  # noqa: E501
-        _cell_register("Insert/Remove > Insert a row below")(_wrap(cmds.selection.insert_row_below))  # noqa: E501
-        _cell_register("Insert/Remove > Remove rows")(_wrap(cmds.selection.remove_selected_rows))  # noqa: E501
+        _cell_register("Insert/Remove > Insert a row above", _wrap(cmds.selection.insert_row_above))  # noqa: E501
+        _cell_register("Insert/Remove > Insert a row below", _wrap(cmds.selection.insert_row_below))  # noqa: E501
+        _cell_register("Insert/Remove > Remove rows", _wrap(cmds.selection.remove_selected_rows))  # noqa: E501
         self._qwidget.addSeparator()
-        _cell_register("Insert/Remove > Insert a column on the left")(_wrap(cmds.selection.insert_column_left))  # noqa: E501
-        _cell_register("Insert/Remove > Insert a column on the right")(_wrap(cmds.selection.insert_column_right))  # noqa: E501
-        _cell_register("Insert/Remove > Remove columns")(_wrap(cmds.selection.remove_selected_columns))  # noqa: E501
+        _cell_register("Insert/Remove > Insert a column on the left", _wrap(cmds.selection.insert_column_left))  # noqa: E501
+        _cell_register("Insert/Remove > Insert a column on the right", _wrap(cmds.selection.insert_column_right))  # noqa: E501
+        _cell_register("Insert/Remove > Remove columns", _wrap(cmds.selection.remove_selected_columns))  # noqa: E501
         self._qwidget.addSeparator()
 
         super()._install_actions()
 
-        _cell_register("Cell widget > SpinBox")(_wrap(cmds.selection.add_spinbox))
-        _cell_register("Cell widget > Slider")(_wrap(cmds.selection.add_slider))
-        _cell_register("Cell widget > FloatSpinBox")(_wrap(cmds.selection.add_float_spinbox))  # noqa: E501
-        _cell_register("Cell widget > FloatSlider")(_wrap(cmds.selection.add_float_slider))  # noqa: E501
-        _cell_register("Cell widget > CheckBox")(_wrap(cmds.selection.add_checkbox))
-        _cell_register("Cell widget > RadioButton")(_wrap(cmds.selection.add_radio_button))  # noqa: E501
-        _cell_register("Cell widget > LineEdit")(_wrap(cmds.selection.add_line_edit))
+        _cell_register("Cell widget > SpinBox", _wrap(cmds.selection.add_spinbox))
+        _cell_register("Cell widget > Slider", _wrap(cmds.selection.add_slider))
+        _cell_register("Cell widget > FloatSpinBox", _wrap(cmds.selection.add_float_spinbox))  # noqa: E501
+        _cell_register("Cell widget > FloatSlider", _wrap(cmds.selection.add_float_slider))  # noqa: E501
+        _cell_register("Cell widget > CheckBox", _wrap(cmds.selection.add_checkbox))
+        _cell_register("Cell widget > RadioButton", _wrap(cmds.selection.add_radio_button))  # noqa: E501
+        _cell_register("Cell widget > LineEdit", _wrap(cmds.selection.add_line_edit))
         self._qwidget.addSeparator("Cell widget ")
-        _cell_register("Cell widget > Remove")(_wrap(cmds.selection.remove_cell_widgets))  # noqa: E501
+        _cell_register("Cell widget > Remove", _wrap(cmds.selection.remove_cell_widgets))  # noqa: E501
 
         # fmt: on
         return None

--- a/tabulous/widgets/_tablelist.py
+++ b/tabulous/widgets/_tablelist.py
@@ -50,7 +50,7 @@ class NamedListEvents(SignalGroup):
     renamed = Signal(int, str)
 
 
-class TableList(EventedList[TableBase], SupportActionRegistration):
+class TableList(EventedList[TableBase], SupportActionRegistration["TableViewer", int]):
     events: NamedListEvents
 
     def __init__(self, parent: TableViewer):
@@ -58,6 +58,10 @@ class TableList(EventedList[TableBase], SupportActionRegistration):
         self.events = NamedListEvents()
         self._parent = parent
         self._install_contextmenu()
+
+    @property
+    def parent(self):
+        return self._parent
 
     def insert(self, index: int, table: TableBase):
         if not isinstance(table, TableBase):
@@ -156,22 +160,22 @@ class TableList(EventedList[TableBase], SupportActionRegistration):
         from tabulous import commands as cmds
 
         def _wrap(cmd):
-            return lambda idx: cmd(self._parent)
+            return lambda *_: cmd(self._parent)
 
         tablestack = self._parent._qwidget._tablestack
 
         # fmt: off
-        self.register_action("Copy all", _wrap(cmds.table.copy_to_clipboard))
-        self.register_action("Rename tab", _wrap(cmds.tab.rename_tab))
-        self.register_action("Delete tab", _wrap(cmds.tab.delete_tab))
+        self.register("Copy all", _wrap(cmds.table.copy_to_clipboard))
+        self.register("Rename tab", _wrap(cmds.tab.rename_tab))
+        self.register("Delete tab", _wrap(cmds.tab.delete_tab))
         tablestack.addSeparator()
-        self.register_action("Reset filter/sort", _wrap(cmds.table.reset_proxy))
+        self.register("Reset filter/sort", _wrap(cmds.table.reset_proxy))
         tablestack.addSeparator()
-        self.register_action("View > Horizontal dual view", _wrap(cmds.view.set_dual_h_mode))  # noqa: E501
-        self.register_action("View > Vertical dual view", _wrap(cmds.view.set_dual_v_mode))  # noqa: E501
-        self.register_action("View > Popup view", _wrap(cmds.view.set_popup_mode))  # noqa: E501
-        self.register_action("View > Reset view", _wrap(cmds.view.reset_view_mode))  # noqa: E501
-        self.register_action("Tile", _wrap(cmds.tab.tile_tables))
-        self.register_action("Untile", _wrap(cmds.tab.untile_table))
+        self.register("View > Horizontal dual view", _wrap(cmds.view.set_dual_h_mode))  # noqa: E501
+        self.register("View > Vertical dual view", _wrap(cmds.view.set_dual_v_mode))  # noqa: E501
+        self.register("View > Popup view", _wrap(cmds.view.set_popup_mode))  # noqa: E501
+        self.register("View > Reset view", _wrap(cmds.view.reset_view_mode))  # noqa: E501
+        self.register("Tile", _wrap(cmds.tab.tile_tables))
+        self.register("Untile", _wrap(cmds.tab.untile_table))
         tablestack.addSeparator()
         # fmt: on

--- a/tabulous/widgets/_tablelist.py
+++ b/tabulous/widgets/_tablelist.py
@@ -173,4 +173,5 @@ class TableList(EventedList[TableBase], SupportActionRegistration):
         self.register_action("View > Reset view", _wrap(cmds.view.reset_view_mode))  # noqa: E501
         self.register_action("Tile", _wrap(cmds.tab.tile_tables))
         self.register_action("Untile", _wrap(cmds.tab.untile_table))
+        tablestack.addSeparator()
         # fmt: on

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -58,16 +58,16 @@ def test_renaming(viewer_cls: type[TableViewerWidget], pos):
 @pytest.mark.parametrize("viewer_cls", [TableViewer, TableViewerWidget])
 def test_register_action(viewer_cls: type[TableViewerWidget]):
     viewer = viewer_cls(show=False)
-    @viewer.tables.register_action
-    def f(i):
+    @viewer.tables.register
+    def f(viewer, i):
         pass
 
-    @viewer.tables.register_action("register-test")
-    def g(i):
+    @viewer.tables.register("register-test")
+    def g(viewer, i):
         pass
 
-    @viewer.tables.register_action("Tests>name")
-    def h(i):
+    @viewer.tables.register("Tests > name")
+    def h(viewrer, i):
         pass
 
 @pytest.mark.parametrize("viewer_cls", [TableViewer, TableViewerWidget])
@@ -93,13 +93,13 @@ def test_bind_keycombo(viewer_cls: type[TableViewerWidget]):
 
     mock = MagicMock()
 
-    viewer.keymap.bind("T")(mock)
+    viewer.keymap.register("T")(mock)
     mock.assert_not_called()
     viewer.keymap.press_key("T")
     mock.assert_called_once()
 
     with pytest.raises(Exception):
-        viewer.keymap.bind("T")(mock)
-    viewer.keymap.bind("T", overwrite=True)(print)
+        viewer.keymap.register("T")(mock)
+    viewer.keymap.register("T", overwrite=True)(print)
 
     viewer.close()


### PR DESCRIPTION
Methods such as `register_action` of table cell, columns etc. and `bind` of keymap object are not convenient now. They should be somehow called *every time before* launching a viewer.

This PR adds a post-initialization architecture. Methods/namespaces can be defined in the `post_init.py` file under the user directory. This change should provide much more flexible customization than `config.toml`.