### PR TITLE
IPython autocompletion of table/column names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,17 @@ fix = true
 "tests/*.py" = ["D", "E501"]
 "examples/*.py" = ["D", "B"]
 "setup.py" = ["F821"]
+
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    "ignore::DeprecationWarning:qtpy",
+    "ignore::DeprecationWarning:ipykernel",
+    "ignore::DeprecationWarning:pkg_resources",
+    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
+    "ignore::DeprecationWarning:qtconsole",
+    "ignore:distutils Version classes are deprecated",
+    "ignore:path is deprecated:DeprecationWarning",
+    "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ matrix.backend.features = [
 ]
 
 [tool.ruff]
-line-length = 79
+line-length = 88
 target-version = "py38"
 fix = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ include = [
     "/tabulous",
 ]
 
+[tool.hatch.envs.test]
+features = ["testing"]
+
 [tool.hatch.envs.test.scripts]
 run = "pytest -v"
 

--- a/tabulous/_keymap/_keymap_objects.py
+++ b/tabulous/_keymap/_keymap_objects.py
@@ -14,7 +14,7 @@ from typing import (
     overload,
 )
 
-from qtpy import QtGui
+from qtpy import QtGui, QT6
 from qtpy.QtCore import Qt
 from functools import reduce
 from operator import or_
@@ -146,6 +146,14 @@ OMEGA = QtGui.QKeySequence("ω")[0]
 
 CYR_A = QtGui.QKeySequence("а")[0]
 CYR_YA = QtGui.QKeySequence("я")[0]
+
+if QT6:
+    # Since Qt6, indexing QKeySequence returns a QKeyCombination object, which
+    # does not support comparison with Qt.Key(int).
+    ALPHA = ALPHA.key()
+    OMEGA = OMEGA.key()
+    CYR_A = CYR_A.key()
+    CYR_YA = CYR_YA.key()
 
 
 class QtKeys:

--- a/tabulous/_qt/_table/_base/_table_base.py
+++ b/tabulous/_qt/_table/_base/_table_base.py
@@ -126,7 +126,10 @@ class QBaseTable(QtW.QSplitter, QActionRegistry[Tuple[int, int]]):
 
     def setOrientation(self, a0: Qt.Orientation) -> None:
         """Set table orientation and the side area orientation."""
-        a1 = 1 - a0  # opposite orientation
+        if a0 == Qt.Orientation.Horizontal:
+            a1 = Qt.Orientation.Vertical
+        else:
+            a1 = Qt.Orientation.Horizontal
         super().setOrientation(a0)
         if self._side_area is not None:
             self._side_area.setOrientation(a1)

--- a/tabulous/widgets/_table.py
+++ b/tabulous/widgets/_table.py
@@ -146,6 +146,9 @@ class TableBase(SupportKeyMap):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}<{self.name!r}>"
 
+    def _ipython_key_completions_(self):
+        return [name for name in self.columns]
+
     # fmt: off
     @overload
     def __getitem__(self, key: str) -> _comp.TableSeries: ...

--- a/tabulous/widgets/_tablelist.py
+++ b/tabulous/widgets/_tablelist.py
@@ -69,6 +69,9 @@ class TableList(EventedList[TableBase], SupportActionRegistration["TableViewer",
         """The QContextMenu widget."""
         return self.parent.native._tablestack._qt_context_menu
 
+    def _ipython_key_completions_(self):
+        return [table.name for table in self]
+
     def insert(self, index: int, table: TableBase):
         """Insert a table at index `index`."""
         if not isinstance(table, TableBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import pytest
-from tabulous._utils import init_config
-from tabulous import TableViewer
 
 @pytest.fixture
 def make_tabulous_viewer():
+    from tabulous._utils import init_config
+    from tabulous import TableViewer
     def func(show=False):
         return TableViewer(show=show)
     with init_config():

--- a/tests/test_keyboard_ops.py
+++ b/tests/test_keyboard_ops.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from tabulous import TableViewer
 import numpy as np
@@ -17,6 +18,8 @@ def test_add_spreadsheet_and_move(qtbot: QtBot):
     assert sheet.cell[0, 0] == "0"
 
 def test_movements_in_popup(qtbot: QtBot):
+    if sys.platform == "darwin":
+        pytest.skip("Skipping test on macOS because it has a different focus policy.")
     viewer = TableViewer()
     qtbot.addWidget(viewer._qwidget)
     sheet = viewer.add_spreadsheet(np.zeros((10, 10)))

--- a/tests/test_table_subset.py
+++ b/tests/test_table_subset.py
@@ -10,7 +10,7 @@ def assert_obj_equal(a, b):
     else:
         assert_series_equal(a, b)
 
-DATA = pd.DataFrame(np.arange(50).reshape(10, 5), columns=list("ABCDE"))
+DATA = pd.DataFrame(np.arange(50, dtype=np.int32).reshape(10, 5), columns=list("ABCDE"))
 
 @pytest.mark.parametrize(
     "sl",


### PR DESCRIPTION
This PR enables autocompletions such as
```python
viewer.tables["
viewer.current_table["
```