### PR TITLE
Fix sort button behavior

### DIFF
--- a/tabulous/_qt/_proxy_button.py
+++ b/tabulous/_qt/_proxy_button.py
@@ -117,10 +117,10 @@ class QHeaderSortButton(_QHeaderSectionButton):
         def _reset():
             if isinstance(f, ComposableSorter):
                 with table._mgr.merging(
-                    lambda cmds: f"Remove filter button at index {index}"
+                    lambda cmds: f"Remove sort button at index {index}"
                 ):
                     table.setHorizontalHeaderWidget(index, None)
-                    table._set_proxy(f.decompose(index))
+                    # table._set_proxy(f.decompose(index))
             else:
                 raise RuntimeError("Sort function is not a ComposableSorter.")
 
@@ -137,6 +137,7 @@ class QHeaderSortButton(_QHeaderSectionButton):
     def on_uninstalled(self, table: QBaseTable, index: int):
         logger.debug(f"Uninstalling sort button at index {index}")
         self.sortSignal.disconnect()
+        self.resetSignal.disconnect()
         f = table._proxy._obj
         if isinstance(f, ComposableSorter):
             table._set_proxy(f.decompose(index))

--- a/tabulous/_qt/_table/_base/_line_edit.py
+++ b/tabulous/_qt/_table/_base/_line_edit.py
@@ -19,6 +19,7 @@ from tabulous._selection_op import (
     construct,
     iter_extract,
 )
+from tabulous import _slice_op as _sl
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -540,7 +541,8 @@ class QCellLiteralEdit(_QTableLineEdit):
         _df_filt = qtable_view.model().df
         _df_ori = qtable._data_raw
         rsl, csl = qtable_view._selection_model.ranges[-1]
-        if not qtable._proxy.is_ordered and not _is_size_one(rsl):
+        col_selected = len(qtable_view._selection_model._col_selection_indices) > 0
+        if not (qtable._proxy.is_ordered or _sl.len_1(rsl) or col_selected):
             self.attachToolTip(
                 "Table proxy is not ordered.\nCannot create cell "
                 "references from table selection."

--- a/tabulous/_sort_filter_proxy.py
+++ b/tabulous/_sort_filter_proxy.py
@@ -413,6 +413,10 @@ class ComposableSorter(Composable):
             self._columns = columns
         self._ascending = ascending
 
+    def __repr__(self) -> str:
+        cname = type(self).__name__
+        return f"{cname}<{self._columns!r}, ascending={self._ascending}>"
+
     def __call__(self, df: pd.DataFrame) -> pd.Series:
         by: list[str] = [df.columns[i] for i in self._columns]
         if len(by) == 1:


### PR DESCRIPTION
- `df.iloc[:, x]` was not allowed during sorting. This PR allows this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated error message in `_sort` function to correctly refer to a "sort" button instead of a "filter" button in `tabulous/_qt/_proxy_button.py`.
- Refactor: Enhanced `_reset` function by adding disconnection of the `resetSignal` for better control flow in `tabulous/_qt/_proxy_button.py`.
- New Feature: Added functionality to check if the table proxy is ordered and if cell references can be created from the table selection in `tabulous/_qt/_table/_base/_line_edit.py`.
- Refactor: Implemented `__repr__` method in `tabulous/_sort_filter_proxy.py` for improved debugging and object information display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->