### PR TITLE
Allow edit object as string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 dependencies = [
     "appdirs>=1.4.4",
     "collections-undo>=0.0.7",
-    "magicgui>=0.5.1",
+    "magicgui>=0.7.0,!=0.8.3",
     "matplotlib>=3.1",
     "pandas>=1.5.2",
     "psygnal>=0.9.0",
@@ -104,3 +104,9 @@ filterwarnings = [
     "ignore:path is deprecated:DeprecationWarning",
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
 ]
+
+[tool.pyright.defineConstant]
+PYQT5 = true
+PYSIDE2 = false
+PYQT6 = false
+PYSIDE6 = false

--- a/tabulous/_magicgui/_color_edit.py
+++ b/tabulous/_magicgui/_color_edit.py
@@ -3,12 +3,7 @@ from typing import Iterable
 from qtpy import QtWidgets as QtW, QtGui
 from qtpy.QtCore import Qt, Signal
 
-from magicgui import __version__ as MAGICGUI_VERSION
-
-if int(MAGICGUI_VERSION.split(".")[1]) >= 7:
-    from magicgui.widgets.bases import ValueWidget
-else:
-    from magicgui.widgets._bases import ValueWidget
+from magicgui.widgets.bases import ValueWidget
 from magicgui.backends._qtpy.widgets import QBaseValueWidget
 from magicgui.application import use_app
 

--- a/tabulous/_magicgui/_timedelta.py
+++ b/tabulous/_magicgui/_timedelta.py
@@ -5,15 +5,10 @@ from typing import TYPE_CHECKING, Union
 from qtpy import QtWidgets as QtW, QtCore, QtGui
 from qtpy.QtCore import Signal
 
-from magicgui import __version__ as MAGICGUI_VERSION, register_type
+from magicgui import register_type
 
-if int(MAGICGUI_VERSION.split(".")[1]) >= 7:
-    from magicgui.widgets.bases import ValueWidget
-    from magicgui.types import Undefined
-else:
-    from magicgui.widgets._bases import ValueWidget
-
-    Undefined = None
+from magicgui.widgets.bases import ValueWidget
+from magicgui.types import Undefined
 
 from magicgui.backends._qtpy.widgets import QBaseValueWidget
 

--- a/tabulous/_magicgui/_toggle_switch.py
+++ b/tabulous/_magicgui/_toggle_switch.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from qtpy import QtWidgets as QtW, QtCore, QtGui
 from qtpy.QtCore import Qt, Signal, Property
 
-try:
-    from magicgui.widgets.bases import ButtonWidget, CategoricalWidget
-except ImportError:
-    from magicgui.widgets._bases import ButtonWidget, CategoricalWidget
+from magicgui.widgets.bases import ButtonWidget, CategoricalWidget
 from magicgui.backends._qtpy.widgets import (
     QBaseButtonWidget,
     RadioButtons as RadioButtonsBase,

--- a/tabulous/_qt/_table/_base/_delegate.py
+++ b/tabulous/_qt/_table/_base/_delegate.py
@@ -4,7 +4,7 @@ from qtpy import QtWidgets as QtW, QtCore, QtGui
 from qtpy.QtCore import Qt
 
 from ._table_base import QBaseTable
-from ._line_edit import QCellLiteralEdit
+from ._line_edit import QCellLiteralEdit, QCellLineEdit
 
 from tabulous._magicgui._timedelta import QTimeDeltaEdit
 
@@ -77,7 +77,9 @@ class TableItemDelegate(QtW.QStyledItemDelegate):
                 td.setValue(value)
                 return td
             elif dtype == "object":
-                raise NotImplementedError("Cannot edit cell of object dtype.")
+                line = QCellLineEdit(parent, qtable_view.parentTable(), (row, col))
+                line.setFont(font)
+                return line
             else:
                 line = qtable_view._create_eval_editor(moveto=(row, col))
                 line.setFont(font)

--- a/tabulous/_qt/_table/_base/_line_edit.py
+++ b/tabulous/_qt/_table/_base/_line_edit.py
@@ -299,6 +299,9 @@ class _EventFilter(QtCore.QObject):
                 return True
         return False
 
+class QCellLineEdit(_QTableLineEdit):
+    def _is_text_valid(self) -> bool:
+        return True
 
 class QCellLiteralEdit(_QTableLineEdit):
     """Line edit used for evaluating cell text."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new `QCellLineEdit` for handling text input in table cells.
  - Enhanced text validation with `_is_text_valid` method.

- **Improvements**
  - Simplified and unified import logic for `magicgui` components.
  - Updated `magicgui` dependency to `>=0.7.0,!=0.8.3` for better compatibility.

- **Bug Fixes**
  - Fixed issue in table cell editor creation for "object" data type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->